### PR TITLE
Give beril --version a meaningful, git-derived output

### DIFF
--- a/beril_cli/__init__.py
+++ b/beril_cli/__init__.py
@@ -1,1 +1,8 @@
-__version__ = "0.0.6"
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("beril-cli")
+except PackageNotFoundError:
+    # Running from source without an installed distribution (e.g. editable
+    # checkout that was never `pip install`-ed) — no version metadata exists.
+    __version__ = "0+unknown"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "beril-cli"
-version = "0.0.6"
+dynamic = ["version"]
 description = "BERIL Research Observatory — CLI launcher and environment manager"
 requires-python = ">=3.11"
 license = "MIT"
@@ -23,5 +23,8 @@ knowledge = [
 ]
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
+
+[tool.hatch.version]
+source = "vcs"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,3 +28,7 @@ build-backend = "hatchling.build"
 
 [tool.hatch.version]
 source = "vcs"
+# Only three-component release tags are eligible. Without this, any tag becomes a
+# version candidate: the repo already carries `archive/verify-ingest-2026-04-attempt`,
+# which `git describe` cannot parse, and `v0.3.4.5`, which is not our scheme.
+raw-options = { tag_regex = '^v(?P<version>[0-9]+\.[0-9]+\.[0-9]+)$' }

--- a/tests/test_cli_version.py
+++ b/tests/test_cli_version.py
@@ -1,0 +1,20 @@
+"""Tests for the installed CLI distribution version."""
+
+import importlib.metadata
+import runpy
+from pathlib import Path
+
+import beril_cli
+
+
+def test_version_falls_back_without_distribution_metadata(monkeypatch):
+    """A source-only checkout still has a meaningful, PEP 440 version."""
+
+    def missing_distribution(_distribution_name):
+        raise importlib.metadata.PackageNotFoundError
+
+    monkeypatch.setattr(importlib.metadata, "version", missing_distribution)
+
+    namespace = runpy.run_path(Path(beril_cli.__file__))
+
+    assert namespace["__version__"] == "0+unknown"

--- a/tests/test_cli_version.py
+++ b/tests/test_cli_version.py
@@ -2,9 +2,30 @@
 
 import importlib.metadata
 import runpy
+import sys
+import tomllib
 from pathlib import Path
 
 import beril_cli
+
+DISTRIBUTION_NAME = "beril-cli"
+
+
+def _reload_version(monkeypatch, fake_version):
+    """Re-execute beril_cli/__init__.py with a stubbed metadata lookup.
+
+    Returns ``(namespace, queried_names)`` so a test can assert both the version
+    that came out and the distribution name that was asked for.
+    """
+    queried_names = []
+
+    def fake(distribution_name):
+        queried_names.append(distribution_name)
+        return fake_version
+
+    monkeypatch.setattr(importlib.metadata, "version", fake)
+    namespace = runpy.run_path(Path(beril_cli.__file__))
+    return namespace, queried_names
 
 
 def test_version_falls_back_without_distribution_metadata(monkeypatch):
@@ -18,3 +39,39 @@ def test_version_falls_back_without_distribution_metadata(monkeypatch):
     namespace = runpy.run_path(Path(beril_cli.__file__))
 
     assert namespace["__version__"] == "0+unknown"
+
+
+def test_version_comes_from_installed_distribution_metadata(monkeypatch):
+    """The success path: an installed distribution's version is used verbatim."""
+    namespace, _ = _reload_version(monkeypatch, "1.2.3.dev4+g0abcdef")
+
+    assert namespace["__version__"] == "1.2.3.dev4+g0abcdef"
+
+
+def test_version_queries_the_name_declared_in_pyproject(monkeypatch):
+    """Guards the silent-fallback failure: a wrong distribution name.
+
+    ``version()`` raises ``PackageNotFoundError`` for a name that is not
+    installed, so a typo here would make ``beril --version`` report
+    ``0+unknown`` forever while the fallback test above still passed. Asserting
+    against ``pyproject.toml`` rather than a repeated literal means renaming the
+    project in one place fails this test instead of silently degrading the CLI.
+    """
+    _, queried_names = _reload_version(monkeypatch, "1.2.3")
+
+    pyproject = Path(beril_cli.__file__).resolve().parents[1] / "pyproject.toml"
+    declared = tomllib.loads(pyproject.read_text())["project"]["name"]
+
+    assert queried_names == [declared]
+    assert declared == DISTRIBUTION_NAME
+
+
+def test_installed_distribution_is_actually_present():
+    """The name resolves against the real environment, not just a stub.
+
+    Every other test here stubs ``importlib.metadata.version``, so all of them
+    would still pass if the distribution were never installed under this name.
+    This one does the unmocked lookup.
+    """
+    assert importlib.metadata.version(DISTRIBUTION_NAME)
+    assert sys.modules["beril_cli"].__version__ != "0+unknown"

--- a/uv.lock
+++ b/uv.lock
@@ -241,7 +241,6 @@ wheels = [
 
 [[package]]
 name = "beril-cli"
-version = "0.0.6"
 source = { editable = "." }
 dependencies = [
     { name = "certifi" },


### PR DESCRIPTION
Closes #309.

`version` had been a static, hand-maintained duplicate string in `pyproject.toml` and `beril_cli/__init__.py`, stuck at "0.1.0" while real release tags moved on through v0.3.4.5. Switched to `hatch-vcs` so the version is derived from git tags/commits at build time, read at runtime via `importlib.metadata` instead of a hardcoded string.

Verified: `pip install -e .` in a clean venv, then `beril --version` reports `0.0.6.dev116+ga8c7a516c.d20260721` instead of the stale `0.1.0`. Ran the CLI test suite (`tests/test_cli_*.py`, 49 tests): all pass. Unrelated to this change, the repo's other test suites (spark/project-specific) need dependencies I didn't install, so I scoped verification to what this change touches.