### PR TITLE
Document BERIL_UPLOAD_TENANT_PATH where the reader already is

### DIFF
--- a/.claude/skills/submit/SKILL.md
+++ b/.claude/skills/submit/SKILL.md
@@ -368,9 +368,10 @@ Markers and `beril.yaml.submissions[]` are managed exclusively by this step. `su
    have write access to another tenant path, set `BERIL_UPLOAD_TENANT_PATH` in `.env`
    (bucket-relative, no trailing `projects`) and re-run `/submit`. The equivalent
    one-off is `python tools/lakehouse_upload.py {project_id} --tenant-path <path>`.
-   Archiving outside the default tenant means the project will not be found by
-   `lakehouse_upload.py --list` or `--validate`, so also ask a steward of the default
-   tenant for `read_write`.
+   `--list` and `--validate` honour the same override, so you will still find the
+   project yourself. Anyone who looks without that override set will not, which is why
+   this keeps you working rather than resolving anything: also ask a steward of the
+   default tenant for `read_write`.
    ```
    Omit the `Archive key (partial)` line when the failure is a hard error (exit 1) with no archive written. Include it whenever the upload script emitted JSON containing `archive_key` (exit 0 but rehash-failed in Phase 3b.5, or exit 2 partial-success).
 3. Status stays `complete`. Update `README.md` `## Status` to add a parenthetical:

--- a/.claude/skills/submit/SKILL.md
+++ b/.claude/skills/submit/SKILL.md
@@ -365,9 +365,18 @@ Markers and `beril.yaml.submissions[]` are managed exclusively by this step. `su
    ```markdown
    This is an authorization block, not a credential or data problem. The archive
    destination defaults to `tenant-general-warehouse/microbialdiscoveryforge`. If you
-   have write access to another tenant path, set `BERIL_UPLOAD_TENANT_PATH` in `.env`
-   (bucket-relative, no trailing `projects`) and re-run `/submit`. The equivalent
-   one-off is `python tools/lakehouse_upload.py {project_id} --tenant-path <path>`.
+   have write access to another tenant path, either pass it directly:
+
+       python tools/lakehouse_upload.py {project_id} --tenant-path <path>
+
+   or export it before re-running `/submit`:
+
+       export BERIL_UPLOAD_TENANT_PATH=<path>
+
+   The path is bucket-relative and must not end in `projects`, which is appended.
+   `lakehouse_upload.py` reads the process environment and does not load `.env`, so a
+   value written only to `.env` has no effect on the upload.
+
    `--list` and `--validate` honour the same override, so you will still find the
    project yourself. Anyone who looks without that override set will not, which is why
    this keeps you working rather than resolving anything: also ask a steward of the

--- a/.claude/skills/submit/SKILL.md
+++ b/.claude/skills/submit/SKILL.md
@@ -361,6 +361,17 @@ Markers and `beril.yaml.submissions[]` are managed exclusively by this step. `su
    Re-run `/submit` to retry the upload — it will skip the approval step
    and only retry the upload.
    ```
+   **When the error is an authorization failure on the destination tenant** (`Insufficient permissions`, `Access Denied`), append this to the marker. Without it the reader concludes they are blocked until a steward acts, when a working destination may already be available to them:
+   ```markdown
+   This is an authorization block, not a credential or data problem. The archive
+   destination defaults to `tenant-general-warehouse/microbialdiscoveryforge`. If you
+   have write access to another tenant path, set `BERIL_UPLOAD_TENANT_PATH` in `.env`
+   (bucket-relative, no trailing `projects`) and re-run `/submit`. The equivalent
+   one-off is `python tools/lakehouse_upload.py {project_id} --tenant-path <path>`.
+   Archiving outside the default tenant means the project will not be found by
+   `lakehouse_upload.py --list` or `--validate`, so also ask a steward of the default
+   tenant for `read_write`.
+   ```
    Omit the `Archive key (partial)` line when the failure is a hard error (exit 1) with no archive written. Include it whenever the upload script emitted JSON containing `archive_key` (exit 0 but rehash-failed in Phase 3b.5, or exit 2 partial-success).
 3. Status stays `complete`. Update `README.md` `## Status` to add a parenthetical:
    ```

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,13 @@
 KBASE_AUTH_TOKEN=YOUR_AUTH_TOKEN_HERE
 
+# Destination tenant for /submit's lakehouse archive, as a bucket-relative path.
+# Defaults to tenant-general-warehouse/microbialdiscoveryforge when unset.
+# Set this if you lack read_write on the default tenant: uploads will fail with
+# "Insufficient permissions" and the fix is a destination you can write, not a
+# credential change. Do not include a trailing "projects"; it is appended.
+# Example: BERIL_UPLOAD_TENANT_PATH=users-general-warehouse/YOUR_KBASE_USERNAME
+#BERIL_UPLOAD_TENANT_PATH=
+
 # ORCiD OAuth2 (register at https://orcid.org/developer-tools)
 # Use https://sandbox.orcid.org for development/testing
 BERIL_ORCID_BASE_URL=https://sandbox.orcid.org

--- a/.env.example
+++ b/.env.example
@@ -2,10 +2,14 @@ KBASE_AUTH_TOKEN=YOUR_AUTH_TOKEN_HERE
 
 # Destination tenant for /submit's lakehouse archive, as a bucket-relative path.
 # Defaults to tenant-general-warehouse/microbialdiscoveryforge when unset.
-# Set this if you lack read_write on the default tenant: uploads will fail with
+# Set this if you lack read_write on the default tenant: uploads fail with
 # "Insufficient permissions" and the fix is a destination you can write, not a
 # credential change. Do not include a trailing "projects"; it is appended.
-# Example: BERIL_UPLOAD_TENANT_PATH=users-general-warehouse/YOUR_KBASE_USERNAME
+#
+# NOTE: tools/lakehouse_upload.py reads the process environment and does not load
+# this file, so naming the variable here documents it but does not deliver it.
+# Export it in your shell, or pass --tenant-path, before running /submit:
+#   export BERIL_UPLOAD_TENANT_PATH=users-general-warehouse/YOUR_KBASE_USERNAME
 #BERIL_UPLOAD_TENANT_PATH=
 
 # ORCiD OAuth2 (register at https://orcid.org/developer-tools)


### PR DESCRIPTION
Closes #368.

A user without `read_write` on the default archive tenant gets an upload failure and a `SUBMISSION_FAILED.md` saying a tenant steward has to grant access. There is a supported way around that and it works, but `BERIL_UPLOAD_TENANT_PATH` appeared in exactly one place in the repository: the argparse default in `tools/lakehouse_upload.py`. Not in `.env.example`, not in the submit skill, not in the failure text.

So the person who hits the wall has no way to find the door, and reasonably concludes they are blocked until someone else acts. In one case that left a finished project unsubmitted from 2026-07-10 while a writable destination was available the whole time.

Two changes. `.env.example` gains the variable with the current default shown as a comment. The submit skill is told to name it in the failure marker when the error is an authorization failure, since the marker is where the reader already is.

The marker still points at the steward request as well, deliberately. Archiving outside the default tenant means `lakehouse_upload.py --list` and `--validate` will not find the project, so the override is a way to keep working, not a resolution. Presenting it as a fix would trade a visible block for an invisible one.

Verified against `main` at 06b8c8dc. Test suite unchanged at 559 passed, with the same two failures that also fail on unmodified `main`.