### PR TITLE
Read only the S3_* env names in observatory_context config

### DIFF
--- a/observatory_context/config.py
+++ b/observatory_context/config.py
@@ -52,11 +52,16 @@ def lakehouse_projects_key(
 def s3_settings() -> dict[str, str | None]:
     """Resolve S3 endpoint + credentials for the object store from the env.
 
-    Reads the vendor-neutral ``S3_*`` names, which is what BERDL sets on a pod.
-    Verified there 2026-08-14: only ``S3_ACCESS_KEY``, ``S3_SECRET_KEY``,
-    ``S3_ENDPOINT_URL`` and ``S3_SECURE`` exist, and no ``MINIO_*`` variable
-    does. Any missing value is ``None`` (caller then falls back to
-    ``berdl-remote`` or treats the tier as unavailable).
+    Returns the three values boto3 needs: ``S3_ENDPOINT_URL``, ``S3_ACCESS_KEY``
+    and ``S3_SECRET_KEY``. Any missing one is ``None``, and the caller then falls
+    back to ``berdl-remote`` or treats the tier as unavailable.
+
+    Only the vendor-neutral ``S3_*`` names are read. BERDL renamed these from
+    ``MINIO_*`` and sets the new names on a pod; verified there 2026-08-14 that
+    ``S3_ACCESS_KEY``, ``S3_SECRET_KEY``, ``S3_ENDPOINT_URL`` and ``S3_SECURE``
+    are present and no ``MINIO_*`` variable is. ``S3_SECURE`` is named here only
+    to record what the pod sets. It is not part of the returned settings; TLS is
+    implied by the ``https`` scheme in the endpoint.
     """
     endpoint = os.getenv("S3_ENDPOINT_URL") or DEFAULT_S3_ENDPOINT_URL
     return {

--- a/observatory_context/config.py
+++ b/observatory_context/config.py
@@ -52,9 +52,11 @@ def lakehouse_projects_key(
 def s3_settings() -> dict[str, str | None]:
     """Resolve S3 endpoint + credentials for the object store from the env.
 
-    Returns the three values boto3 needs: ``S3_ENDPOINT_URL``, ``S3_ACCESS_KEY``
-    and ``S3_SECRET_KEY``. Any missing one is ``None``, and the caller then falls
-    back to ``berdl-remote`` or treats the tier as unavailable.
+    Returns the three values boto3 needs. ``endpoint_url`` is always a string:
+    it falls back to :data:`DEFAULT_S3_ENDPOINT_URL` when ``S3_ENDPOINT_URL`` is
+    unset. ``access_key`` and ``secret_key`` are ``None`` when their variables
+    are unset, and only those two signal "unconfigured" to the caller, which then
+    falls back to ``berdl-remote`` or treats the tier as unavailable.
 
     Only the vendor-neutral ``S3_*`` names are read. BERDL renamed these from
     ``MINIO_*`` and sets the new names on a pod; verified there 2026-08-14 that

--- a/observatory_context/config.py
+++ b/observatory_context/config.py
@@ -27,9 +27,8 @@ LAKEHOUSE_TENANT_PATH = "tenant-general-warehouse/microbialdiscoveryforge"
 LAKEHOUSE_PROJECTS_PREFIX = "projects"
 
 # Default S3 endpoint for the object store. MinIO today; the lakehouse is moving
-# to Ceph (RADOS Gateway), which speaks the same S3 API — so the endpoint is
-# resolved from the environment (``S3_ENDPOINT_URL`` first, then the legacy
-# ``MINIO_ENDPOINT_URL``) and the Ceph cutover is an env change, not a code edit.
+# to Ceph (RADOS Gateway), which speaks the same S3 API, so the endpoint is read
+# from ``S3_ENDPOINT_URL`` and the Ceph cutover is an env change, not a code edit.
 DEFAULT_S3_ENDPOINT_URL = "https://minio.berdl.kbase.us"
 
 
@@ -53,21 +52,17 @@ def lakehouse_projects_key(
 def s3_settings() -> dict[str, str | None]:
     """Resolve S3 endpoint + credentials for the object store from the env.
 
-    Endpoint and key lookups both prefer the vendor-neutral ``S3_*`` names
-    (Ceph-ready) and fall back to the legacy ``MINIO_*`` names, so the Ceph
-    cutover is an env change rather than a code edit. Any missing value is
-    ``None`` (caller then falls back to ``berdl-remote`` or treats the tier as
-    unavailable).
+    Reads the vendor-neutral ``S3_*`` names, which is what BERDL sets on a pod.
+    Verified there 2026-08-14: only ``S3_ACCESS_KEY``, ``S3_SECRET_KEY``,
+    ``S3_ENDPOINT_URL`` and ``S3_SECURE`` exist, and no ``MINIO_*`` variable
+    does. Any missing value is ``None`` (caller then falls back to
+    ``berdl-remote`` or treats the tier as unavailable).
     """
-    endpoint = (
-        os.getenv("S3_ENDPOINT_URL")
-        or os.getenv("MINIO_ENDPOINT_URL")
-        or DEFAULT_S3_ENDPOINT_URL
-    )
+    endpoint = os.getenv("S3_ENDPOINT_URL") or DEFAULT_S3_ENDPOINT_URL
     return {
         "endpoint_url": endpoint,
-        "access_key": os.getenv("S3_ACCESS_KEY") or os.getenv("MINIO_ACCESS_KEY"),
-        "secret_key": os.getenv("S3_SECRET_KEY") or os.getenv("MINIO_SECRET_KEY"),
+        "access_key": os.getenv("S3_ACCESS_KEY"),
+        "secret_key": os.getenv("S3_SECRET_KEY"),
     }
 
 

--- a/tests/knowledge/test_config.py
+++ b/tests/knowledge/test_config.py
@@ -125,9 +125,12 @@ class TestCachedCredentialImportGuard:
 
 
 class TestS3Settings:
-    """`S3_*` env vars take precedence over legacy `MINIO_*`, symmetrically for
-    endpoint and both keys. This is what makes the Ceph cutover an env change
-    rather than a code edit — regression on any leg would silently break that."""
+    """Only the `S3_*` env vars are read, for the endpoint and both keys.
+
+    BERDL renamed these from `MINIO_*` to `S3_*` and sets only the new names on a
+    pod (verified there 2026-08-14). Reading `MINIO_*` as well would let a stale
+    value on a developer machine resolve instead of the real one, so the tests
+    below assert those names are ignored rather than merely unused."""
 
     def test_defaults_when_no_env(self, clear_s3_env):
         result = s3_settings()
@@ -137,19 +140,21 @@ class TestS3Settings:
             "secret_key": None,
         }
 
-    def test_minio_legacy_env_still_works(self, clear_s3_env, monkeypatch):
+    def test_minio_names_are_ignored(self, clear_s3_env, monkeypatch):
+        # A machine still carrying the old exports must resolve as unconfigured,
+        # not as configured with stale values.
         monkeypatch.setenv("MINIO_ENDPOINT_URL", "https://minio.example/")
         monkeypatch.setenv("MINIO_ACCESS_KEY", "minio-ak")
         monkeypatch.setenv("MINIO_SECRET_KEY", "minio-sk")
 
         result = s3_settings()
         assert result == {
-            "endpoint_url": "https://minio.example/",
-            "access_key": "minio-ak",
-            "secret_key": "minio-sk",
+            "endpoint_url": DEFAULT_S3_ENDPOINT_URL,
+            "access_key": None,
+            "secret_key": None,
         }
 
-    def test_s3_env_wins_over_minio(self, clear_s3_env, monkeypatch):
+    def test_s3_names_win_when_both_are_set(self, clear_s3_env, monkeypatch):
         monkeypatch.setenv("S3_ENDPOINT_URL", "https://ceph.example/")
         monkeypatch.setenv("MINIO_ENDPOINT_URL", "https://minio.example/")
         monkeypatch.setenv("S3_ACCESS_KEY", "s3-ak")
@@ -164,10 +169,9 @@ class TestS3Settings:
             "secret_key": "s3-sk",
         }
 
-    def test_mixed_precedence_per_field(self, clear_s3_env, monkeypatch):
-        # Each of endpoint/access/secret independently prefers S3_ over MINIO_,
-        # so a partial rollout (S3_ACCESS_KEY set but not yet S3_SECRET_KEY)
-        # still resolves cleanly instead of silently going all-legacy.
+    def test_partial_s3_config_does_not_fall_back(self, clear_s3_env, monkeypatch):
+        # Endpoint and both keys resolve independently. With only S3_ACCESS_KEY
+        # set, the other two stay unset rather than picking up a MINIO_ value.
         monkeypatch.setenv("S3_ACCESS_KEY", "s3-ak")
         monkeypatch.setenv("MINIO_ACCESS_KEY", "minio-ak")
         monkeypatch.setenv("MINIO_SECRET_KEY", "minio-sk")
@@ -175,7 +179,7 @@ class TestS3Settings:
 
         result = s3_settings()
         assert result == {
-            "endpoint_url": "https://minio.example/",
+            "endpoint_url": DEFAULT_S3_ENDPOINT_URL,
             "access_key": "s3-ak",
-            "secret_key": "minio-sk",
+            "secret_key": None,
         }


### PR DESCRIPTION
## Why

BERDL renamed the object-store credential variables from `MINIO_*` to `S3_*`. On a pod only the new names exist: `S3_ACCESS_KEY`, `S3_SECRET_KEY`, `S3_ENDPOINT_URL` and `S3_SECURE`, with no `MINIO_*` variable present. Verified by reading the environment on a pod on 2026-08-14.

`observatory_context/config.py` still read both. That is worse than dead code: a developer machine carrying an old `MINIO_ACCESS_KEY` export resolves as configured, with a stale value, instead of resolving as unconfigured and falling through to `berdl-remote`. It also implies a backwards-compatibility contract with an image that no longer exists, since pods cycle.

## What changed

`s3_settings()` reads only the `S3_*` names. The three tests that covered the fallback now assert the old names are ignored rather than honored, so the removal is checked rather than only absent.

## Validation

`pytest tests/` , 754 passed. The inverted assertion in `test_minio_names_are_ignored` fails against the previous behavior, so the new tests are load-bearing rather than decorative.

## Scope

Companion to https://github.com/kbaseincubator/BERIL-research-observatory/pull/380 , which does the same for the scripts, the CLI and the skills. Zero file overlap between the two, confirmed against the API, so they can merge in either order.

Split out rather than folded into 380 because @mikacashman scoped that PR deliberately and I offered her the choice of taking this here or as a follow-up. This is the follow-up. If you would rather it went into 380, say so and I will move it.