### PR TITLE
Pin openviking-sdk in PEP723 knowledge scripts

### DIFF
--- a/knowledge/scripts/check_openviking_health.py
+++ b/knowledge/scripts/check_openviking_health.py
@@ -3,6 +3,7 @@
 # requires-python = ">=3.11"
 # dependencies = [
 #     "openviking==0.4.15",
+#     "openviking-sdk==0.1.8",
 #     "pyyaml",
 #     "rich",
 # ]

--- a/knowledge/scripts/ingest_context.py
+++ b/knowledge/scripts/ingest_context.py
@@ -3,6 +3,7 @@
 # requires-python = ">=3.11"
 # dependencies = [
 #     "openviking==0.4.15",
+#     "openviking-sdk==0.1.8",
 #     "httpx",
 #     "pyyaml",
 #     "rich",

--- a/knowledge/scripts/knowledge_query.py
+++ b/knowledge/scripts/knowledge_query.py
@@ -3,6 +3,7 @@
 # requires-python = ">=3.11"
 # dependencies = [
 #     "openviking==0.4.15",
+#     "openviking-sdk==0.1.8",
 #     "pyyaml",
 #     "boto3",
 # ]

--- a/knowledge/scripts/setup_remote_ov.py
+++ b/knowledge/scripts/setup_remote_ov.py
@@ -4,6 +4,7 @@
 # dependencies = [
 #     "httpx",
 #     "openviking==0.4.15",
+#     "openviking-sdk==0.1.8",
 # ]
 # ///
 """One-time setup for the remote OpenViking knowledge server.

--- a/knowledge/scripts/smoke_ingest_openviking.py
+++ b/knowledge/scripts/smoke_ingest_openviking.py
@@ -3,6 +3,7 @@
 # requires-python = ">=3.11"
 # dependencies = [
 #     "openviking==0.4.15",
+#     "openviking-sdk==0.1.8",
 #     "pyyaml",
 #     "rich",
 # ]


### PR DESCRIPTION
Fixes #402

## Problem

The five `knowledge/scripts/*.py` PEP723 scripts pinned `openviking==0.4.15` but left the transitive `openviking-sdk` floating — `openviking` declares only `openviking-sdk>=0.1.1`.

The project venv gets 0.1.8 via `uv.lock`. A PEP723 script has no lock, so `uv run --script` resolved the newest SDK, and 0.1.9 dropped the `reason` parameter from `add_resource()`. `observatory_context/ingest.py:322` passes `reason=`, so it raised `TypeError: add_resource() got an unexpected keyword argument 'reason'` under the script envs while succeeding from the project venv.

## Fix

Add `"openviking-sdk==0.1.8"` to each script's dependency block, matching what `uv.lock` resolves:

- `knowledge/scripts/ingest_context.py`
- `knowledge/scripts/check_openviking_health.py`
- `knowledge/scripts/knowledge_query.py`
- `knowledge/scripts/smoke_ingest_openviking.py`
- `knowledge/scripts/setup_remote_ov.py`

## Verification

Reproduced the issue's table by direct measurement:

| env | openviking-sdk | `add_resource` params | `reason` |
|---|---|---|---|
| unpinned (before) | 0.1.9 | 7 | absent |
| pinned (after) | 0.1.8 | 21 | present |

All five scripts now resolve `openviking-sdk 0.1.8` in isolated script envs and import / `--help` cleanly.

## Not covered

The issue's second "done when" condition — `ingest_context.py` completing an ingest against a running server — is **not** verified here; this was developed off-hub with no OpenViking server reachable. The failing call path and the restored signature are both confirmed, but the end-to-end run should be checked before merge.

Note: the pin is a hard `==` to match the lock, so bumping the SDK now means updating the lock and these five blocks together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
