### PR TITLE
Read S3_ENDPOINT_URL in the eight data/ ingest scripts

### DIFF
--- a/data/alphafold_collection/scripts/ingest_alphafold.py
+++ b/data/alphafold_collection/scripts/ingest_alphafold.py
@@ -64,7 +64,7 @@ def get_minio_client():
     """Create MinIO client with BERDL credentials."""
     creds = get_minio_credentials()
     settings = get_settings()
-    endpoint = settings.MINIO_ENDPOINT_URL.replace("https://", "").replace(
+    endpoint = settings.S3_ENDPOINT_URL.replace("https://", "").replace(
         "http://", ""
     )
     client = Minio(

--- a/data/alphafold_collection/scripts/ingest_alphafold.py
+++ b/data/alphafold_collection/scripts/ingest_alphafold.py
@@ -16,10 +16,9 @@ Usage:
 import argparse
 import os
 
-from berdl_notebook_utils.berdl_settings import get_settings
-from berdl_notebook_utils.minio_governance import get_minio_credentials
+from berdl_notebook_utils import get_s3_client
+from berdl_notebook_utils.governance import get_credentials
 from data_lakehouse_ingest import ingest
-from minio import Minio
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 DATA_DIR = "/pscratch/sd/p/psdehal/alphafold_collection"
@@ -62,17 +61,8 @@ INGEST_CONFIG = {
 
 def get_minio_client():
     """Create MinIO client with BERDL credentials."""
-    creds = get_minio_credentials()
-    settings = get_settings()
-    endpoint = settings.S3_ENDPOINT_URL.replace("https://", "").replace(
-        "http://", ""
-    )
-    client = Minio(
-        endpoint=endpoint,
-        access_key=creds.access_key,
-        secret_key=creds.secret_key,
-        secure=True,
-    )
+    creds = get_credentials()
+    client = get_s3_client()
     print(f"MinIO client ready (user: {creds.username})")
     return client
 

--- a/data/bacdive_ingest/ingest_bacdive.py
+++ b/data/bacdive_ingest/ingest_bacdive.py
@@ -36,7 +36,7 @@ def main():
     # Get MinIO credentials
     creds = get_minio_credentials()
     settings = get_settings()
-    endpoint = settings.MINIO_ENDPOINT_URL.replace("https://", "").replace("http://", "")
+    endpoint = settings.S3_ENDPOINT_URL.replace("https://", "").replace("http://", "")
 
     minio_client = Minio(
         endpoint=endpoint,

--- a/data/bacdive_ingest/ingest_bacdive.py
+++ b/data/bacdive_ingest/ingest_bacdive.py
@@ -10,9 +10,8 @@ Prerequisites:
 
 import os
 import json
-from berdl_notebook_utils.minio_governance import get_minio_credentials
-from berdl_notebook_utils.berdl_settings import get_settings
-from minio import Minio
+from berdl_notebook_utils.governance import get_credentials
+from berdl_notebook_utils import get_s3_client
 from data_lakehouse_ingest import ingest
 
 LOCAL_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -34,16 +33,8 @@ FILES_TO_UPLOAD = [
 
 def main():
     # Get MinIO credentials
-    creds = get_minio_credentials()
-    settings = get_settings()
-    endpoint = settings.S3_ENDPOINT_URL.replace("https://", "").replace("http://", "")
-
-    minio_client = Minio(
-        endpoint=endpoint,
-        access_key=creds.access_key,
-        secret_key=creds.secret_key,
-        secure=True,
-    )
+    creds = get_credentials()
+    minio_client = get_s3_client()
     print(f"MinIO client ready (user: {creds.username})")
 
     # Upload files

--- a/data/bakta_reannotation/scripts/ingest_bakta.py
+++ b/data/bakta_reannotation/scripts/ingest_bakta.py
@@ -40,7 +40,7 @@ def main():
     # Get MinIO credentials
     creds = get_minio_credentials()
     settings = get_settings()
-    endpoint = settings.MINIO_ENDPOINT_URL.replace("https://", "").replace(
+    endpoint = settings.S3_ENDPOINT_URL.replace("https://", "").replace(
         "http://", ""
     )
 

--- a/data/bakta_reannotation/scripts/ingest_bakta.py
+++ b/data/bakta_reannotation/scripts/ingest_bakta.py
@@ -17,10 +17,9 @@ Usage:
 
 import os
 
-from berdl_notebook_utils.berdl_settings import get_settings
-from berdl_notebook_utils.minio_governance import get_minio_credentials
+from berdl_notebook_utils import get_s3_client
+from berdl_notebook_utils.governance import get_credentials
 from data_lakehouse_ingest import ingest
-from minio import Minio
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 FINAL_DIR = "/pscratch/sd/p/psdehal/bakta_reannotation/tables/final"
@@ -38,18 +37,8 @@ FILES_TO_UPLOAD = [
 
 def main():
     # Get MinIO credentials
-    creds = get_minio_credentials()
-    settings = get_settings()
-    endpoint = settings.S3_ENDPOINT_URL.replace("https://", "").replace(
-        "http://", ""
-    )
-
-    minio_client = Minio(
-        endpoint=endpoint,
-        access_key=creds.access_key,
-        secret_key=creds.secret_key,
-        secure=True,
-    )
+    creds = get_credentials()
+    minio_client = get_s3_client()
     print(f"MinIO client ready (user: {creds.username})")
 
     # Upload files

--- a/data/bakta_reannotation/scripts/run_ingest.py
+++ b/data/bakta_reannotation/scripts/run_ingest.py
@@ -74,7 +74,7 @@ INGEST_CONFIG = {
 def main():
     creds = get_minio_credentials()
     settings = get_settings()
-    endpoint = settings.MINIO_ENDPOINT_URL.replace("https://", "").replace("http://", "")
+    endpoint = settings.S3_ENDPOINT_URL.replace("https://", "").replace("http://", "")
 
     minio_client = Minio(
         endpoint=endpoint,

--- a/data/bakta_reannotation/scripts/run_ingest.py
+++ b/data/bakta_reannotation/scripts/run_ingest.py
@@ -12,10 +12,9 @@ Usage:
   python run_ingest.py
 """
 
-from berdl_notebook_utils.berdl_settings import get_settings
-from berdl_notebook_utils.minio_governance import get_minio_credentials
+from berdl_notebook_utils import get_s3_client
+from berdl_notebook_utils.governance import get_credentials
 from data_lakehouse_ingest import ingest
-from minio import Minio
 
 BUCKET = "cdm-lake"
 USER_PREFIX = "users-general-warehouse/psdehal/data/bakta_reannotation"
@@ -72,16 +71,8 @@ INGEST_CONFIG = {
 
 
 def main():
-    creds = get_minio_credentials()
-    settings = get_settings()
-    endpoint = settings.S3_ENDPOINT_URL.replace("https://", "").replace("http://", "")
-
-    minio_client = Minio(
-        endpoint=endpoint,
-        access_key=creds.access_key,
-        secret_key=creds.secret_key,
-        secure=True,
-    )
+    creds = get_credentials()
+    minio_client = get_s3_client()
     print(f"MinIO client ready (user: {creds.username})")
 
     # Verify source files exist

--- a/data/interpro_lookup/scripts/04_ingest_interpro.py
+++ b/data/interpro_lookup/scripts/04_ingest_interpro.py
@@ -23,9 +23,8 @@ import os
 import sys
 import time
 
-from berdl_notebook_utils.berdl_settings import get_settings
-from berdl_notebook_utils.minio_governance import get_minio_credentials
-from minio import Minio
+from berdl_notebook_utils import get_s3_client
+from berdl_notebook_utils.governance import get_credentials
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 PREPARED_DIR = os.path.join(os.path.dirname(SCRIPT_DIR), "prepared")
@@ -44,17 +43,8 @@ FILES = [
 
 def get_minio_client():
     """Create MinIO client from BERDL credentials."""
-    creds = get_minio_credentials()
-    settings = get_settings()
-    endpoint = settings.S3_ENDPOINT_URL.replace("https://", "").replace(
-        "http://", ""
-    )
-    client = Minio(
-        endpoint=endpoint,
-        access_key=creds.access_key,
-        secret_key=creds.secret_key,
-        secure=True,
-    )
+    creds = get_credentials()
+    client = get_s3_client()
     print(f"MinIO client ready (user: {creds.username})")
     return client
 

--- a/data/interpro_lookup/scripts/04_ingest_interpro.py
+++ b/data/interpro_lookup/scripts/04_ingest_interpro.py
@@ -46,7 +46,7 @@ def get_minio_client():
     """Create MinIO client from BERDL credentials."""
     creds = get_minio_credentials()
     settings = get_settings()
-    endpoint = settings.MINIO_ENDPOINT_URL.replace("https://", "").replace(
+    endpoint = settings.S3_ENDPOINT_URL.replace("https://", "").replace(
         "http://", ""
     )
     client = Minio(

--- a/data/interpro_lookup/scripts/06_probe_lookup_service.py
+++ b/data/interpro_lookup/scripts/06_probe_lookup_service.py
@@ -169,7 +169,7 @@ def _download_md5s_from_s3(s3_path: str, expected_rows: int):
 
     settings = get_settings()
     creds = get_minio_credentials()
-    endpoint = settings.MINIO_ENDPOINT_URL.replace("https://", "").replace("http://", "")
+    endpoint = settings.S3_ENDPOINT_URL.replace("https://", "").replace("http://", "")
     client = Minio(
         endpoint=endpoint,
         access_key=creds.access_key,

--- a/data/interpro_lookup/scripts/06_probe_lookup_service.py
+++ b/data/interpro_lookup/scripts/06_probe_lookup_service.py
@@ -163,19 +163,11 @@ def cmd_extract(args):
 
 def _download_md5s_from_s3(s3_path: str, expected_rows: int):
     """Download CSV part files from S3 and merge into a single local TSV."""
-    from berdl_notebook_utils.berdl_settings import get_settings
-    from berdl_notebook_utils.minio_governance import get_minio_credentials
-    from minio import Minio
+    from berdl_notebook_utils import get_s3_client
+    from berdl_notebook_utils.governance import get_credentials
 
-    settings = get_settings()
-    creds = get_minio_credentials()
-    endpoint = settings.S3_ENDPOINT_URL.replace("https://", "").replace("http://", "")
-    client = Minio(
-        endpoint=endpoint,
-        access_key=creds.access_key,
-        secret_key=creds.secret_key,
-        secure=True,
-    )
+    creds = get_credentials()
+    client = get_s3_client()
 
     # Parse bucket and prefix from s3a:// path
     path = s3_path.replace("s3a://", "")

--- a/data/interpro_lookup/scripts/10_ingest_interproscan_results.py
+++ b/data/interpro_lookup/scripts/10_ingest_interproscan_results.py
@@ -84,7 +84,7 @@ INGEST_CONFIG = {
 def get_minio_client():
     creds = get_minio_credentials()
     settings = get_settings()
-    endpoint = settings.MINIO_ENDPOINT_URL.replace("https://", "").replace("http://", "")
+    endpoint = settings.S3_ENDPOINT_URL.replace("https://", "").replace("http://", "")
     client = Minio(
         endpoint=endpoint,
         access_key=creds.access_key,

--- a/data/interpro_lookup/scripts/10_ingest_interproscan_results.py
+++ b/data/interpro_lookup/scripts/10_ingest_interproscan_results.py
@@ -26,10 +26,9 @@ import argparse
 import os
 import sys
 
-from berdl_notebook_utils.berdl_settings import get_settings
-from berdl_notebook_utils.minio_governance import get_minio_credentials
+from berdl_notebook_utils import get_s3_client
+from berdl_notebook_utils.governance import get_credentials
 from data_lakehouse_ingest import ingest
-from minio import Minio
 
 BUCKET = "cdm-lake"
 MINIO_PREFIX = "users-general-warehouse/psdehal/data/interproscan_results"
@@ -82,15 +81,8 @@ INGEST_CONFIG = {
 
 
 def get_minio_client():
-    creds = get_minio_credentials()
-    settings = get_settings()
-    endpoint = settings.S3_ENDPOINT_URL.replace("https://", "").replace("http://", "")
-    client = Minio(
-        endpoint=endpoint,
-        access_key=creds.access_key,
-        secret_key=creds.secret_key,
-        secure=True,
-    )
+    creds = get_credentials()
+    client = get_s3_client()
     print(f"MinIO client ready (user: {creds.username})")
     return client
 

--- a/data/pdb_collection/scripts/ingest_pdb.py
+++ b/data/pdb_collection/scripts/ingest_pdb.py
@@ -39,7 +39,7 @@ def get_minio_client():
     """Create MinIO client with BERDL credentials."""
     creds = get_minio_credentials()
     settings = get_settings()
-    endpoint = settings.MINIO_ENDPOINT_URL.replace("https://", "").replace("http://", "")
+    endpoint = settings.S3_ENDPOINT_URL.replace("https://", "").replace("http://", "")
     client = Minio(
         endpoint=endpoint,
         access_key=creds.access_key,

--- a/data/pdb_collection/scripts/ingest_pdb.py
+++ b/data/pdb_collection/scripts/ingest_pdb.py
@@ -14,10 +14,9 @@ import argparse
 import json
 import os
 
-from berdl_notebook_utils.berdl_settings import get_settings
-from berdl_notebook_utils.minio_governance import get_minio_credentials
+from berdl_notebook_utils import get_s3_client
+from berdl_notebook_utils.governance import get_credentials
 from data_lakehouse_ingest import ingest
-from minio import Minio
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 DATA_DIR = "/pscratch/sd/p/psdehal/pdb_collection"
@@ -37,15 +36,8 @@ with open(os.path.join(SCRIPT_DIR, "pdb_collection.json")) as f:
 
 def get_minio_client():
     """Create MinIO client with BERDL credentials."""
-    creds = get_minio_credentials()
-    settings = get_settings()
-    endpoint = settings.S3_ENDPOINT_URL.replace("https://", "").replace("http://", "")
-    client = Minio(
-        endpoint=endpoint,
-        access_key=creds.access_key,
-        secret_key=creds.secret_key,
-        secure=True,
-    )
+    creds = get_credentials()
+    client = get_s3_client()
     print(f"MinIO client ready (user: {creds.username})")
     return client
 

--- a/scripts/ingest_lib.py
+++ b/scripts/ingest_lib.py
@@ -81,7 +81,10 @@ _STUB_MODULES = [
     "berdl_notebook_utils.spark.database",
     "berdl_notebook_utils.spark.cluster",
     "berdl_notebook_utils.spark.dataframe",
+    # Renamed upstream to `.governance`; the old path survives as a shim for one
+    # release, so stub both until that shim is gone.
     "berdl_notebook_utils.minio_governance",
+    "berdl_notebook_utils.governance",
 ]
 for _name in _STUB_MODULES:
     if _name not in sys.modules:

--- a/tests/test_no_dead_berdl_settings.py
+++ b/tests/test_no_dead_berdl_settings.py
@@ -1,19 +1,20 @@
-"""Guard against reading BERDL settings attributes that no longer exist.
+"""Guard against BERDL names that a current pod no longer provides.
 
-BERDL renamed its object-store settings from ``MINIO_*`` to ``S3_*``. A current
-pod's ``BERDLSettings`` has ``S3_ACCESS_KEY``, ``S3_SECRET_KEY``,
-``S3_ENDPOINT_URL`` and ``S3_SECURE``, and no ``MINIO_*`` attribute at all, so
-``settings.MINIO_ENDPOINT_URL`` raises ``AttributeError`` rather than returning a
-stale value.
+BERDL renamed three things on the way from ``MINIO_*`` to ``S3_*``, and each one
+fails in a different way at a different moment: a missing settings attribute
+raises ``AttributeError`` at call time, a renamed module and a renamed function
+raise ``ImportError`` at import time.
 
-That failure only shows up when a script is actually run on a pod, which is why
-it survived in eight `data/` scripts for months. This test is static: it needs no
-pod, no credentials and no BERDL packages, so CI catches a reintroduction the
-same day rather than the next time someone runs an ingest.
+Every one of them is invisible until the code runs on a pod, which is how eight
+`data/` scripts stayed broken for months while reading fine. This test is static,
+so it needs no pod, no credentials and no BERDL packages, and CI catches a
+reintroduction the same day rather than the next time someone runs an ingest.
 
-Fixed across three pull requests before this guard existed: 380 (the credential
-resolver and skill docs), 401 (``observatory_context/config.py``) and 381 (the
-eight `data/` ingest scripts).
+The endpoint rename alone was fixed three times before this guard existed: in
+pull requests 380 (the credential resolver and skill docs), 401
+(``observatory_context/config.py``) and 412 (the eight `data/` scripts). The
+other two renames were only found by running the code on a pod, after 412 had
+already been opened claiming the fix was complete.
 """
 
 from __future__ import annotations
@@ -23,10 +24,30 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
-# Attribute access on a settings object, e.g. ``settings.MINIO_ENDPOINT_URL``.
-# Deliberately not matching ``os.environ["MINIO_..."]`` or prose: an env var that
-# is merely absent gives a clean fallback, while a missing attribute raises.
-DEAD_ATTRIBUTE = re.compile(r"\.MINIO_[A-Z][A-Z0-9_]*\b")
+# Three separate renames, all of which only fail when run on a pod.
+#
+#  1. Attribute access on a settings object, e.g. ``settings.MINIO_ENDPOINT_URL``.
+#     Deliberately not matching ``os.environ["MINIO_..."]`` or prose: an env var
+#     that is merely absent falls back cleanly, a missing attribute raises.
+#  2. ``berdl_notebook_utils.minio_governance``, renamed to ``.governance``. The
+#     module survives as a shim for one release; the functions inside did not.
+#  3. ``get_minio_credentials``, renamed to ``get_credentials``, whose result
+#     also renamed ``access_key``/``secret_key`` to ``s3_access_key``/
+#     ``s3_secret_key``.
+#
+# Prefer ``berdl_notebook_utils.get_s3_client()``, which builds the client and
+# sidesteps all three.
+DEAD_PATTERNS = {
+    "settings attribute that no longer exists": re.compile(r"\.MINIO_[A-Z][A-Z0-9_]*\b"),
+    # Import statements only. `scripts/ingest_lib.py` legitimately names the old
+    # module as a string, because it stubs whatever `data_lakehouse_ingest`
+    # imports and the shim is still there for one release.
+    "module renamed to berdl_notebook_utils.governance": re.compile(
+        r"^\s*(?:from\s+berdl_notebook_utils\.minio_governance\s+import"
+        r"|import\s+berdl_notebook_utils\.minio_governance)\b"
+    ),
+    "function renamed to get_credentials": re.compile(r"\bget_minio_credentials\b"),
+}
 
 SKIP_DIRS = {".git", ".venv", ".venv-berdl", "node_modules", "__pycache__"}
 
@@ -42,28 +63,42 @@ def _python_files() -> list[Path]:
     return out
 
 
-def test_no_python_file_reads_a_minio_settings_attribute():
-    """No file may read ``<settings>.MINIO_*``; BERDL no longer defines those."""
+def test_no_python_file_uses_a_removed_berdl_api():
+    """Nothing may use a BERDL name that a current pod no longer provides."""
     offenders = []
     for path in _python_files():
         text = path.read_text(encoding="utf-8", errors="replace")
         for lineno, line in enumerate(text.splitlines(), 1):
-            if DEAD_ATTRIBUTE.search(line):
-                rel = path.relative_to(REPO_ROOT)
-                offenders.append(f"{rel}:{lineno}: {line.strip()}")
+            for why, pattern in DEAD_PATTERNS.items():
+                if pattern.search(line):
+                    rel = path.relative_to(REPO_ROOT)
+                    offenders.append(f"{rel}:{lineno}: {why}\n      {line.strip()}")
 
     assert not offenders, (
-        "These read a BERDL settings attribute that no longer exists and will "
-        "raise AttributeError on a current pod. Use the S3_* name instead:\n  "
+        "These use a BERDL name that no longer exists, so they fail on a current "
+        "pod. berdl_notebook_utils.get_s3_client() replaces all of them:\n  "
         + "\n  ".join(offenders)
     )
 
 
 def test_the_guard_can_actually_fail():
-    """A test that never fails guards nothing, so prove the pattern matches."""
-    assert DEAD_ATTRIBUTE.search("endpoint = settings.MINIO_ENDPOINT_URL.replace(")
-    assert DEAD_ATTRIBUTE.search("x = cfg.MINIO_SECRET_KEY")
-    # and does not fire on the things it should leave alone
-    assert not DEAD_ATTRIBUTE.search('os.environ["MINIO_ENDPOINT_URL"]')
-    assert not DEAD_ATTRIBUTE.search("settings.S3_ENDPOINT_URL")
-    assert not DEAD_ATTRIBUTE.search("# historically this was MINIO_ENDPOINT_URL")
+    """A test that never fails guards nothing, so prove each pattern matches."""
+    attr = DEAD_PATTERNS["settings attribute that no longer exists"]
+    module = DEAD_PATTERNS["module renamed to berdl_notebook_utils.governance"]
+    func = DEAD_PATTERNS["function renamed to get_credentials"]
+
+    assert attr.search("endpoint = settings.MINIO_ENDPOINT_URL.replace(")
+    assert attr.search("x = cfg.MINIO_SECRET_KEY")
+    assert module.search(
+        "from berdl_notebook_utils.minio_governance import get_credentials"
+    )
+    # a stub-list entry names the module as data, not as an import
+    assert not module.search('    "berdl_notebook_utils.minio_governance",')
+    assert func.search("creds = get_minio_credentials()")
+
+    # and none of them fire on what they should leave alone
+    assert not attr.search('os.environ["MINIO_ENDPOINT_URL"]')
+    assert not attr.search("settings.S3_ENDPOINT_URL")
+    assert not attr.search("# historically this was MINIO_ENDPOINT_URL")
+    assert not module.search("from berdl_notebook_utils.governance import get_credentials")
+    assert not func.search("creds = get_credentials()")

--- a/tests/test_no_dead_berdl_settings.py
+++ b/tests/test_no_dead_berdl_settings.py
@@ -1,0 +1,69 @@
+"""Guard against reading BERDL settings attributes that no longer exist.
+
+BERDL renamed its object-store settings from ``MINIO_*`` to ``S3_*``. A current
+pod's ``BERDLSettings`` has ``S3_ACCESS_KEY``, ``S3_SECRET_KEY``,
+``S3_ENDPOINT_URL`` and ``S3_SECURE``, and no ``MINIO_*`` attribute at all, so
+``settings.MINIO_ENDPOINT_URL`` raises ``AttributeError`` rather than returning a
+stale value.
+
+That failure only shows up when a script is actually run on a pod, which is why
+it survived in eight `data/` scripts for months. This test is static: it needs no
+pod, no credentials and no BERDL packages, so CI catches a reintroduction the
+same day rather than the next time someone runs an ingest.
+
+Fixed across three pull requests before this guard existed: 380 (the credential
+resolver and skill docs), 401 (``observatory_context/config.py``) and 381 (the
+eight `data/` ingest scripts).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# Attribute access on a settings object, e.g. ``settings.MINIO_ENDPOINT_URL``.
+# Deliberately not matching ``os.environ["MINIO_..."]`` or prose: an env var that
+# is merely absent gives a clean fallback, while a missing attribute raises.
+DEAD_ATTRIBUTE = re.compile(r"\.MINIO_[A-Z][A-Z0-9_]*\b")
+
+SKIP_DIRS = {".git", ".venv", ".venv-berdl", "node_modules", "__pycache__"}
+
+
+def _python_files() -> list[Path]:
+    out = []
+    for path in REPO_ROOT.rglob("*.py"):
+        if SKIP_DIRS & set(path.relative_to(REPO_ROOT).parts):
+            continue
+        if path.resolve() == Path(__file__).resolve():
+            continue
+        out.append(path)
+    return out
+
+
+def test_no_python_file_reads_a_minio_settings_attribute():
+    """No file may read ``<settings>.MINIO_*``; BERDL no longer defines those."""
+    offenders = []
+    for path in _python_files():
+        text = path.read_text(encoding="utf-8", errors="replace")
+        for lineno, line in enumerate(text.splitlines(), 1):
+            if DEAD_ATTRIBUTE.search(line):
+                rel = path.relative_to(REPO_ROOT)
+                offenders.append(f"{rel}:{lineno}: {line.strip()}")
+
+    assert not offenders, (
+        "These read a BERDL settings attribute that no longer exists and will "
+        "raise AttributeError on a current pod. Use the S3_* name instead:\n  "
+        + "\n  ".join(offenders)
+    )
+
+
+def test_the_guard_can_actually_fail(tmp_path):
+    """A test that never fails guards nothing, so prove the pattern matches."""
+    assert DEAD_ATTRIBUTE.search("endpoint = settings.MINIO_ENDPOINT_URL.replace(")
+    assert DEAD_ATTRIBUTE.search("x = cfg.MINIO_SECRET_KEY")
+    # and does not fire on the things it should leave alone
+    assert not DEAD_ATTRIBUTE.search('os.environ["MINIO_ENDPOINT_URL"]')
+    assert not DEAD_ATTRIBUTE.search("settings.S3_ENDPOINT_URL")
+    assert not DEAD_ATTRIBUTE.search("# historically this was MINIO_ENDPOINT_URL")

--- a/tests/test_no_dead_berdl_settings.py
+++ b/tests/test_no_dead_berdl_settings.py
@@ -59,7 +59,7 @@ def test_no_python_file_reads_a_minio_settings_attribute():
     )
 
 
-def test_the_guard_can_actually_fail(tmp_path):
+def test_the_guard_can_actually_fail():
     """A test that never fails guards nothing, so prove the pattern matches."""
     assert DEAD_ATTRIBUTE.search("endpoint = settings.MINIO_ENDPOINT_URL.replace(")
     assert DEAD_ATTRIBUTE.search("x = cfg.MINIO_SECRET_KEY")


### PR DESCRIPTION
Closes https://github.com/beril-doe/BERIL-research-observatory/issues/381

## Why

The eight `data/` ingest scripts cannot run on a current pod. The issue described one cause; running them found three.

BERDL renamed three things on the way from `MINIO_*` to `S3_*`, and each fails at a different moment:

| what | how it fails |
|---|---|
| `settings.MINIO_ENDPOINT_URL` | `AttributeError` at call time |
| `berdl_notebook_utils.minio_governance` | renamed to `.governance` |
| `get_minio_credentials` | renamed to `get_credentials`, and its `access_key`/`secret_key` fields renamed to `s3_access_key`/`s3_secret_key` |

The import raises before the endpoint is ever read, so fixing only the attribute, which is what this PR originally did, makes the scripts fail later rather than fail less. That is worth stating plainly because the issue's own suggested fix has the same gap.

## What changed

BERDL now ships `berdl_notebook_utils.get_s3_client()`, which returns the same `minio.api.Minio` these scripts were assembling by hand. Each script now calls it instead of reading a settings attribute, building an endpoint string, and passing credential fields. That removes all three failure points at once and leaves nothing to re-break on the next rename.

Also drops the now-unused `from minio import Minio` from all eight, and the hardcoded `secure=True`, which `get_s3_client()` derives from `S3_SECURE`.

## Verified on a pod, not inferred

```
BERDLSettings object-store attributes: ['S3_ACCESS_KEY', 'S3_ENDPOINT_URL', 'S3_SECRET_KEY', 'S3_SECURE']

OLD line, as the eight scripts had it:
   AttributeError: 'BERDLSettings' object has no attribute 'MINIO_ENDPOINT_URL'

get_s3_client() -> minio.api.Minio
buckets: ['cdm-lake', 'cdm-spark-job-logs', 'cts']
```

## The guard

This class of bug has been fixed three times, in https://github.com/beril-doe/BERIL-research-observatory/pull/380 , https://github.com/beril-doe/BERIL-research-observatory/pull/401 and here, and each time it was invisible until someone ran the code. `tests/test_no_dead_berdl_settings.py` fails on any of the three renamed names anywhere in the tree. It is static, so it needs no pod or credentials.

It found something outside `data/` on its first run: `scripts/ingest_lib.py` stubs `berdl_notebook_utils.minio_governance` so `data_lakehouse_ingest` loads off-cluster, and had not gained the new module name. That list is updated. The module pattern matches import statements only, since naming a module in a stub list is data rather than a broken import, and the self-test pins that distinction so nobody loosens it later.

## Validation

- Full suite 756 passed.
- Each of the three patterns proven load-bearing by reintroducing that name into one script and watching the guard fail.
- `python -m compileall` clean across all five script directories.

## Still open, and not for this PR

Whether these scripts are rerun or are a record of how a collection was built. It does not gate the fix, since they cannot currently run at all, but someone who knows should say, because it decides whether they are worth keeping at all.