### PR TITLE
Load .env in lakehouse_upload so BERIL_UPLOAD_TENANT_PATH works

### DIFF
--- a/tests/test_lakehouse_upload.py
+++ b/tests/test_lakehouse_upload.py
@@ -828,3 +828,25 @@ def test_main_reads_tenant_path_from_dotenv(lu, repo, monkeypatch, capsys):
     lu.main()
 
     assert "tenant-general-warehouse/nmdc" in capsys.readouterr().out
+
+
+def test_load_dotenv_strips_inline_comments(lu, tmp_path, monkeypatch):
+    """`.env.example` itself writes `KEY=value  # note`, so this shape is real."""
+    for name in ("WITH_NOTE", "QUOTED_NOTE", "HASH_IN_VALUE", "QUOTED_HASH"):
+        monkeypatch.delenv(name, raising=False)
+    env = tmp_path / ".env"
+    env.write_text(
+        "WITH_NOTE=tenant-general-warehouse/nmdc  # use the nmdc tenant\n"
+        'QUOTED_NOTE="spaced value"  # trailing note\n'
+        "HASH_IN_VALUE=abc#def\n"
+        'QUOTED_HASH="abc # def"\n'
+    )
+
+    applied = lu.load_dotenv(env)
+
+    assert applied["WITH_NOTE"] == "tenant-general-warehouse/nmdc"
+    assert applied["QUOTED_NOTE"] == "spaced value"
+    # no whitespace before the #, so it is part of the value, not a comment
+    assert applied["HASH_IN_VALUE"] == "abc#def"
+    # inside quotes it is always literal
+    assert applied["QUOTED_HASH"] == "abc # def"

--- a/tests/test_lakehouse_upload.py
+++ b/tests/test_lakehouse_upload.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -749,3 +750,81 @@ def test_main_no_args_prints_help(lu, monkeypatch, capsys):
     monkeypatch.setattr(sys, "argv", ["lakehouse_upload.py"])
     lu.main()
     assert "usage:" in capsys.readouterr().out
+
+
+# --- .env loading (issue 379) -------------------------------------------------
+#
+# The tool read BERIL_UPLOAD_TENANT_PATH from os.environ and never loaded .env,
+# so putting the variable in the obvious place changed nothing and produced the
+# same permission failure with no clue why. These pin both the parsing and the
+# precedence, because "env wins over file" is what keeps an explicit export or
+# --tenant-path from being silently overridden.
+
+
+def test_load_dotenv_sets_names_from_the_file(lu, tmp_path, monkeypatch):
+    monkeypatch.delenv("BERIL_UPLOAD_TENANT_PATH", raising=False)
+    env = tmp_path / ".env"
+    env.write_text("BERIL_UPLOAD_TENANT_PATH=tenant-general-warehouse/nmdc\n")
+
+    applied = lu.load_dotenv(env)
+
+    assert applied == {"BERIL_UPLOAD_TENANT_PATH": "tenant-general-warehouse/nmdc"}
+    assert os.environ["BERIL_UPLOAD_TENANT_PATH"] == "tenant-general-warehouse/nmdc"
+
+
+def test_load_dotenv_does_not_override_the_environment(lu, tmp_path, monkeypatch):
+    """An explicit export must beat the file, or --tenant-path becomes a lie."""
+    monkeypatch.setenv("BERIL_UPLOAD_TENANT_PATH", "from-the-environment")
+    env = tmp_path / ".env"
+    env.write_text("BERIL_UPLOAD_TENANT_PATH=from-the-file\n")
+
+    applied = lu.load_dotenv(env)
+
+    assert applied == {}
+    assert os.environ["BERIL_UPLOAD_TENANT_PATH"] == "from-the-environment"
+
+
+def test_load_dotenv_handles_the_shapes_a_real_env_file_has(lu, tmp_path, monkeypatch):
+    for name in ("PLAIN", "QUOTED", "SINGLE", "EXPORTED", "SPACED", "WITH_EQUALS", "EMPTY"):
+        monkeypatch.delenv(name, raising=False)
+    env = tmp_path / ".env"
+    env.write_text(
+        "# a comment\n"
+        "\n"
+        "PLAIN=value\n"
+        'QUOTED="quoted value"\n'
+        "SINGLE='single quoted'\n"
+        "export EXPORTED=exported\n"
+        "  SPACED  =  spaced  \n"
+        "WITH_EQUALS=a=b=c\n"
+        "EMPTY=\n"
+        "NOT_AN_ASSIGNMENT\n"
+    )
+
+    applied = lu.load_dotenv(env)
+
+    assert applied["PLAIN"] == "value"
+    assert applied["QUOTED"] == "quoted value"
+    assert applied["SINGLE"] == "single quoted"
+    assert applied["EXPORTED"] == "exported"
+    assert applied["SPACED"] == "spaced"
+    assert applied["WITH_EQUALS"] == "a=b=c"
+    assert applied["EMPTY"] == ""
+    assert "NOT_AN_ASSIGNMENT" not in applied
+
+
+def test_load_dotenv_is_quiet_when_there_is_no_file(lu, tmp_path):
+    assert lu.load_dotenv(tmp_path / "does-not-exist") == {}
+
+
+def test_main_reads_tenant_path_from_dotenv(lu, repo, monkeypatch, capsys):
+    """The bug this fixes, end to end: the file alone must change the target."""
+    monkeypatch.delenv("BERIL_UPLOAD_TENANT_PATH", raising=False)
+    (repo / ".env").write_text("BERIL_UPLOAD_TENANT_PATH=tenant-general-warehouse/nmdc\n")
+    monkeypatch.setattr(lu, "REPO_ROOT", repo)
+    monkeypatch.setattr(lu, "list_projects", lambda: print(lu.S3A_BASE))
+    monkeypatch.setattr(sys, "argv", ["lakehouse_upload.py", "--list"])
+
+    lu.main()
+
+    assert "tenant-general-warehouse/nmdc" in capsys.readouterr().out

--- a/tools/lakehouse_upload.py
+++ b/tools/lakehouse_upload.py
@@ -17,6 +17,7 @@ Usage (Python):
 import argparse
 import json
 import os
+import re
 import subprocess
 import sys
 import time
@@ -68,13 +69,24 @@ def load_dotenv(env_path: Path | None = None) -> dict[str, str]:
         if not key:
             continue
         value = value.strip()
-        if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
-            value = value[1:-1]
+        if value[:1] in ("'", '"'):
+            # Quoted: take the quoted span and ignore any trailing comment. A
+            # `#` inside the quotes is part of the value.
+            quote = value[0]
+            end = value.find(quote, 1)
+            value = value[1:end] if end != -1 else value[1:]
+        else:
+            # Unquoted: strip an inline comment. `.env.example` uses this style
+            # on several lines, which is what makes it worth handling. The
+            # whitespace before `#` is required, so a value that merely contains
+            # a `#` (a fragment, a generated secret) survives intact.
+            value = re.split(r"\s#", value, maxsplit=1)[0].rstrip()
         if key in os.environ:
             continue
         os.environ[key] = value
         applied[key] = value
     return applied
+
 
 # Files/directories to skip during the manifest walk. The manifest is the
 # source of truth for what gets uploaded — upload_project iterates the

--- a/tools/lakehouse_upload.py
+++ b/tools/lakehouse_upload.py
@@ -31,6 +31,51 @@ LAKEHOUSE_BASE = f"{MC_ALIAS}/{BUCKET}/{TENANT_PATH}/projects"
 # S3a path for documentation and Spark references
 S3A_BASE = f"s3a://{BUCKET}/{TENANT_PATH}/projects"
 
+# Repo root, derived from this file's own location rather than the cwd, because
+# `--base-path` defaults to "." and cannot be consulted before the parser that
+# defines it has been built.
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def load_dotenv(env_path: Path | None = None) -> dict[str, str]:
+    """Load ``.env`` into ``os.environ`` without overriding what is already set.
+
+    Deliberately stdlib only. This tool runs under whatever interpreter the
+    caller has active, which frequently lacks packages (see the note on the
+    context-service mirror below), so taking a dependency on ``python-dotenv``
+    here would break it in exactly the environments it is built to survive.
+
+    Anything already in the environment wins, so an explicit ``export`` or a
+    ``--tenant-path`` argument still beats the file. Returns the names it set,
+    with values, so a caller can report what came from the file; the return is
+    a convenience for tests and is not logged, since values may be secrets.
+    """
+    path = env_path if env_path is not None else REPO_ROOT / ".env"
+    applied: dict[str, str] = {}
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return applied
+
+    for line in raw.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or "=" not in stripped:
+            continue
+        if stripped.startswith("export "):
+            stripped = stripped[len("export ") :].lstrip()
+        key, _, value = stripped.partition("=")
+        key = key.strip()
+        if not key:
+            continue
+        value = value.strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+            value = value[1:-1]
+        if key in os.environ:
+            continue
+        os.environ[key] = value
+        applied[key] = value
+    return applied
+
 # Files/directories to skip during the manifest walk. The manifest is the
 # source of truth for what gets uploaded — upload_project iterates the
 # manifest directly rather than `mc cp --recursive`, so any name in this
@@ -581,6 +626,11 @@ def clean_tenant_path(raw):
 
 
 def main():
+    # Before the parser is built, because `--tenant-path` takes its default from
+    # os.environ at add_argument() time. Loading afterwards would read the file
+    # and change nothing, which is the bug this fixes.
+    load_dotenv()
+
     parser = argparse.ArgumentParser(
         description="Upload BERIL Observatory projects to the BERDL lakehouse (MinIO)."
     )


### PR DESCRIPTION
Closes https://github.com/beril-doe/BERIL-research-observatory/issues/379

## Why

`tools/lakehouse_upload.py` read `BERIL_UPLOAD_TENANT_PATH` from `os.environ` and never loaded `.env`. The submit skill runs it as a plain `python tools/lakehouse_upload.py {project_id}`, so nothing else loaded the file either. A user who put the variable in the obvious place changed nothing and got the same permission failure with no clue why.

## Where it is loaded, and why there

Before the parser is built. `--tenant-path` takes its default from `os.environ` at `add_argument()` time, so loading afterwards would read the file and change nothing, which is the same shape as the original bug.

Anything already in the environment wins, so an explicit `export` or an explicit `--tenant-path` still beats the file.

## Deviating from the issue's suggested fix, deliberately

The issue suggests `python-dotenv` and declaring it in `pyproject.toml`. I used stdlib instead, because this file imports only stdlib today and its own comment says why:

> this upload tool runs under whatever interpreter the caller has active (which frequently lacks the `openviking` SDK, e.g. the webapp venv)

A hard `from dotenv import load_dotenv` would break it in exactly the environments that note is about. Worth flagging rather than doing quietly, since it is a departure from what the issue asked for.

## A correction to the issue, for whoever picks up the consolidation

The issue says the repo has three answers to "how do I read `.env`" and names `scripts/ingest_preflight.py` as the one using the `dotenv` library. It does not: `ingest_preflight.py:24` hand-rolls `_load_dotenv()` with `split("=")`.

Counting properly, **11** files hand-roll a parser, not six:

```
beril_cli/doctor.py                                        scripts/discover_berdl_collections.py
beril_cli/setup_cmd.py                                     scripts/export_sql.py
projects/microbeatlas_metal_ecology/scripts/enigma_validation.py   scripts/get_minio_creds.py
projects/pangenome_pathway_geography/verify_data_availability.py   scripts/get_spark_session.py
scripts/detect_berdl_environment.py                        scripts/ingest_preflight.py
                                                           scripts/run_sql.py
```

The 10 files that do use the library are all under `projects/` and `data/`, so the split is not "some tooling uses the library" but "no tooling does". That makes the consolidation the issue anticipates larger than it looks, and it is still its own issue.

## Validation

- Full suite 759 passed.
- Tests cover the precedence, the shapes a real `.env` has (comments, blank lines, `export` prefix, both quote styles, `=` inside a value, empty value, a line with no assignment), a missing file, and the end-to-end case where the file alone changes the upload target.
- Verified load-bearing rather than assumed: disabling the `load_dotenv()` call fails the end-to-end test and nothing else, which is the right blast radius for a one-line call.

## Follow-up this unblocks

The caveat added to `.env.example` and to the failure marker in the closed PR 378 can be deleted once this lands, since the file would then behave the way it reads. Not done here to keep the diff to the fix.