### PR TITLE
automatically resolve openviking credentials for users (2/4?)

### DIFF
--- a/ui/app/context_manager/base.py
+++ b/ui/app/context_manager/base.py
@@ -3,8 +3,6 @@ from pathlib import Path
 
 from pydantic import BaseModel
 
-from app.db.models import BerilUser
-
 
 class FileMetadata(BaseModel):
     created: datetime
@@ -39,15 +37,15 @@ class ContextManager:
     url: str
     config: dict[str, str]
 
-    async def get_file(self, user: BerilUser, path: Path) -> ContextFile:
+    async def get_file(self, path: Path) -> ContextFile:
         ...
 
-    async def insert_file(self, user: BerilUser, file: ContextFile) -> bool:
+    async def insert_file(self, file: ContextFile) -> bool:
         ...
 
-    async def list_files(self, user: BerilUser) -> list[ContextFile]:
+    async def list_files(self) -> list[ContextFile]:
         ...
 
-    async def query(self, user: BerilUser, query: ContextQuery) -> ContextQueryResults:
+    async def query(self, query: ContextQuery) -> ContextQueryResults:
         ...
 

--- a/ui/app/context_manager/openviking.py
+++ b/ui/app/context_manager/openviking.py
@@ -1,7 +1,18 @@
+import logging
 from pathlib import Path
 
-from app.clients.openviking import OpenVikingClient
-from app.config import Settings
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.clients.openviking import (
+    OpenVikingClient,
+    OpenVikingError,
+    regenerate_ov_user_key,
+    register_ov_user,
+)
+from app.config import Settings, get_settings
+from app.crypto import decrypt_secret, encrypt_secret
+from app.db.crud import get_ov_credential, upsert_ov_credential
+from app.db.models import BerilUser
 
 from .base import (
     ContextFile,
@@ -10,6 +21,16 @@ from .base import (
     ContextQueryResults,
     QueryResult,
 )
+
+logger = logging.getLogger(__name__)
+
+
+class UnauthenticatedError(RuntimeError):
+    """Raised when a context-manager call is made without an identified user."""
+
+
+class OvProvisioningError(RuntimeError):
+    """Raised when a user's OpenViking credential can't be obtained or minted."""
 
 
 class OpenVikingManager(ContextManager):
@@ -50,3 +71,75 @@ class OpenVikingManager(ContextManager):
         )
         await ov_client.close()
         return processed
+
+async def get_user_ov_api_key(db: AsyncSession, user: BerilUser) -> str:
+    """
+    Fetches the OpenViking api key for an authenticated user.
+    If user is None or doesn't have an id, raises an UnauthenticatedError.
+    If the user has no OpenViking api key, this creates the user in
+    OpenViking (and locally) and returns the api key.
+
+    Provisioning is transparent to the caller: the OpenViking account is an
+    implementation detail, so a user who already exists upstream but has no key
+    stored here is silently issued a fresh one rather than surfacing a conflict.
+    That invalidates any prior key for that OV user — acceptable because BERIL
+    is the only legitimate holder, and a key BERIL cannot read is unusable here.
+
+    Raises OvProvisioningError if OpenViking is unreachable or returns no key.
+    """
+    if user is None or not getattr(user, "id", None):
+        raise UnauthenticatedError(
+            "An authenticated user is required to access OpenViking."
+        )
+
+    settings = get_settings()
+
+    existing = await get_ov_credential(db, user.id)
+    if existing is not None:
+        return decrypt_secret(existing.encrypted_key, settings.ov_credential_key)
+
+    # ov_user_id is always the authenticated user's ORCiD — never caller input.
+    ov_user_id = user.orcid_id
+    try:
+        result = await register_ov_user(ov_user_id)
+    except OpenVikingError as exc:
+        if exc.status_code != 409 and exc.code != "ALREADY_EXISTS":
+            logger.warning("OpenViking register_user failed for %s: %s", user.id, exc)
+            raise OvProvisioningError(f"OpenViking user creation failed: {exc}") from exc
+        # The OV user outlives BERIL's copy of its key (a dropped credential
+        # row, a restored backup, a rotated encryption key). Mint a replacement
+        # so the user never has to know OpenViking is involved.
+        logger.info(
+            "OpenViking user %s exists without a stored BERIL key; regenerating",
+            ov_user_id,
+        )
+        try:
+            result = await regenerate_ov_user_key(ov_user_id)
+        except OpenVikingError as regen_exc:
+            logger.warning(
+                "OpenViking regenerate_key failed for %s: %s", user.id, regen_exc
+            )
+            raise OvProvisioningError(
+                f"OpenViking key regeneration failed: {regen_exc}"
+            ) from regen_exc
+
+    user_key = (result or {}).get("user_key")
+    if not user_key:
+        raise OvProvisioningError(
+            "OpenViking did not return a user key."
+        )
+
+    await upsert_ov_credential(
+        db,
+        user.id,
+        account_id=settings.ov_account_id,
+        ov_user_id=ov_user_id,
+        encrypted_key=encrypt_secret(user_key, settings.ov_credential_key),
+    )
+    logger.info(
+        "Stored OpenViking credential for BERIL user %s (orcid %s)",
+        user.id,
+        user.orcid_id,
+    )
+    return user_key
+

--- a/ui/app/routes/context.py
+++ b/ui/app/routes/context.py
@@ -10,22 +10,46 @@ within BERIL's context manager implementation.
 
 import logging
 
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth import BerilUser, require_user_api
 from app.config import get_settings
-from app.context_manager.openviking import ContextQuery, OpenVikingManager
-from app.crypto import decrypt_secret
-from app.db.crud import get_ov_credential
-from app.db.models import OvUserCredential
+from app.context_manager.openviking import (
+    ContextQuery,
+    OpenVikingManager,
+    OvProvisioningError,
+    UnauthenticatedError,
+    get_user_ov_api_key,
+)
 from app.db.session import get_db
 
 logger = logging.getLogger()
 
-def get_context_manager(cred: OvUserCredential) -> OpenVikingManager:
-    key = get_settings().ov_credential_key
-    return OpenVikingManager(get_settings(), decrypt_secret(cred.encrypted_key, key))
+def get_context_manager(api_key: str) -> OpenVikingManager:
+    return OpenVikingManager(get_settings(), api_key)
+
+
+async def resolve_context_manager(
+    db: AsyncSession, user: BerilUser
+) -> OpenVikingManager:
+    """Build a context manager for ``user``, provisioning their backing
+    credential on first use.
+
+    The backing store is an implementation detail, so its failures surface as
+    a generic 502 rather than anything the user is expected to act on.
+    """
+    try:
+        api_key = await get_user_ov_api_key(db, user)
+    except UnauthenticatedError as exc:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED) from exc
+    except OvProvisioningError as exc:
+        logger.warning("Context manager unavailable for user %s: %s", user.id, exc)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="The context manager is currently unavailable.",
+        ) from exc
+    return get_context_manager(api_key)
 
 
 ROUTER_CONTEXT = APIRouter(tags=["context"])
@@ -38,8 +62,8 @@ async def post_context_find(
     db: AsyncSession = Depends(get_db)
 ):
     logger.info(f"Running context query: {query}")
-    ov_credential = await get_ov_credential(db, user.id)
-    return await get_context_manager(ov_credential).query(query)
+    manager = await resolve_context_manager(db, user)
+    return await manager.query(query)
 
 @ROUTER_CONTEXT.get("/api/context/ls")
 async def get_context_files(
@@ -47,5 +71,5 @@ async def get_context_files(
     user: BerilUser = Depends(require_user_api),
     db: AsyncSession = Depends(get_db)
 ):
-    ov_credential = await get_ov_credential(db, user.id)
-    return await get_context_manager(ov_credential).list_files()
+    manager = await resolve_context_manager(db, user)
+    return await manager.list_files()

--- a/ui/tests/test_context_manager.py
+++ b/ui/tests/test_context_manager.py
@@ -14,15 +14,25 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from cryptography.fernet import Fernet
 
-from app.clients.openviking import OpenVikingClient
+from app.clients.openviking import OpenVikingClient, OpenVikingError
 from app.context_manager.base import ContextQuery, ContextQueryResults
-from app.context_manager.openviking import OpenVikingManager
+from app.context_manager.openviking import (
+    OpenVikingManager,
+    OvProvisioningError,
+    UnauthenticatedError,
+    get_user_ov_api_key,
+)
+from app.crypto import decrypt_secret, encrypt_secret
+from app.db.crud import get_ov_credential
+from app.db.models import BerilUser, OvUserCredential
+
+_CREDENTIAL_KEY = Fernet.generate_key().decode()
 
 _ENV = {
     "BERIL_OV_URL": "http://ov.test:1933",
     "BERIL_OV_ACCOUNT_ID": "beril",
     "BERIL_OV_ADMIN_KEY": "admin-key",
-    "BERIL_OV_CREDENTIAL_KEY": Fernet.generate_key().decode(),
+    "BERIL_OV_CREDENTIAL_KEY": _CREDENTIAL_KEY,
     "BERIL_SESSION_SECRET_KEY": "test-session-secret",
 }
 
@@ -242,6 +252,135 @@ async def test_list_files_closes_the_client(settings, patched_sdk):
     await manager.list_files()
 
     patched_sdk.close.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# get_user_ov_api_key
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def ov_user(db_session):
+    u = BerilUser(orcid_id="0000-0001-2345-6789", display_name="Alice Researcher")
+    db_session.add(u)
+    await db_session.commit()
+    await db_session.refresh(u)
+    return u
+
+
+def _already_exists() -> OpenVikingError:
+    return OpenVikingError("exists", status_code=409, code="ALREADY_EXISTS")
+
+
+async def test_get_key_requires_a_user(settings, db_session):
+    with pytest.raises(UnauthenticatedError):
+        await get_user_ov_api_key(db_session, None)
+
+
+async def test_get_key_requires_a_persisted_user(settings, db_session):
+    """A BerilUser that was never committed has no id — treat as unauthenticated."""
+    with pytest.raises(UnauthenticatedError):
+        await get_user_ov_api_key(db_session, BerilUser(orcid_id="0000-0001-2345-6789"))
+
+
+async def test_get_key_returns_decrypted_stored_key(settings, db_session, ov_user):
+    db_session.add(
+        OvUserCredential(
+            user_id=ov_user.id,
+            account_id="beril",
+            ov_user_id=ov_user.orcid_id,
+            encrypted_key=encrypt_secret("stored-key", _CREDENTIAL_KEY),
+        )
+    )
+    await db_session.commit()
+
+    with patch("app.context_manager.openviking.register_ov_user") as register:
+        key = await get_user_ov_api_key(db_session, ov_user)
+
+    assert key == "stored-key"
+    # An existing credential must never trigger an upstream call.
+    register.assert_not_called()
+
+
+async def test_get_key_provisions_and_stores_on_first_use(settings, db_session, ov_user):
+    register = AsyncMock(return_value={"user_key": "minted-key"})
+    with patch("app.context_manager.openviking.register_ov_user", register):
+        key = await get_user_ov_api_key(db_session, ov_user)
+
+    assert key == "minted-key"
+    register.assert_awaited_once_with(ov_user.orcid_id)
+
+    cred = await get_ov_credential(db_session, ov_user.id)
+    assert cred is not None
+    assert cred.ov_user_id == ov_user.orcid_id
+    assert cred.account_id == "beril"
+    # Persisted encrypted, but round-trips to the plaintext we returned.
+    assert cred.encrypted_key != "minted-key"
+    assert decrypt_secret(cred.encrypted_key, _CREDENTIAL_KEY) == "minted-key"
+
+
+async def test_get_key_regenerates_when_ov_user_exists_without_key(
+    settings, db_session, ov_user
+):
+    """The 409 case resolves silently — the user never sees an OV conflict."""
+    register = AsyncMock(side_effect=_already_exists())
+    regenerate = AsyncMock(return_value={"user_key": "regen-key"})
+    with patch("app.context_manager.openviking.register_ov_user", register), patch(
+        "app.context_manager.openviking.regenerate_ov_user_key", regenerate
+    ):
+        key = await get_user_ov_api_key(db_session, ov_user)
+
+    assert key == "regen-key"
+    regenerate.assert_awaited_once_with(ov_user.orcid_id)
+
+    cred = await get_ov_credential(db_session, ov_user.id)
+    assert decrypt_secret(cred.encrypted_key, _CREDENTIAL_KEY) == "regen-key"
+
+
+async def test_get_key_regenerates_on_bare_already_exists_code(
+    settings, db_session, ov_user
+):
+    """OV signals the conflict by code even when the status isn't 409."""
+    register = AsyncMock(
+        side_effect=OpenVikingError("exists", code="ALREADY_EXISTS")
+    )
+    regenerate = AsyncMock(return_value={"user_key": "regen-key"})
+    with patch("app.context_manager.openviking.register_ov_user", register), patch(
+        "app.context_manager.openviking.regenerate_ov_user_key", regenerate
+    ):
+        assert await get_user_ov_api_key(db_session, ov_user) == "regen-key"
+
+
+async def test_get_key_raises_when_registration_fails(settings, db_session, ov_user):
+    register = AsyncMock(
+        side_effect=OpenVikingError("boom", status_code=500, code="INTERNAL")
+    )
+    with patch("app.context_manager.openviking.register_ov_user", register):
+        with pytest.raises(OvProvisioningError):
+            await get_user_ov_api_key(db_session, ov_user)
+
+    assert await get_ov_credential(db_session, ov_user.id) is None
+
+
+async def test_get_key_raises_when_regeneration_fails(settings, db_session, ov_user):
+    """A conflict we then can't recover from is a real upstream fault."""
+    register = AsyncMock(side_effect=_already_exists())
+    regenerate = AsyncMock(side_effect=OpenVikingError("nope", status_code=502))
+    with patch("app.context_manager.openviking.register_ov_user", register), patch(
+        "app.context_manager.openviking.regenerate_ov_user_key", regenerate
+    ):
+        with pytest.raises(OvProvisioningError):
+            await get_user_ov_api_key(db_session, ov_user)
+
+
+async def test_get_key_raises_when_no_key_returned(settings, db_session, ov_user):
+    """A success envelope without a ``user_key`` is unusable."""
+    register = AsyncMock(return_value={"user_id": "someone"})
+    with patch("app.context_manager.openviking.register_ov_user", register):
+        with pytest.raises(OvProvisioningError):
+            await get_user_ov_api_key(db_session, ov_user)
+
+    assert await get_ov_credential(db_session, ov_user.id) is None
 
 
 # ---------------------------------------------------------------------------

--- a/ui/tests/test_routes_context.py
+++ b/ui/tests/test_routes_context.py
@@ -16,6 +16,7 @@ import pytest
 from cryptography.fernet import Fernet
 from fastapi.testclient import TestClient
 
+from app.clients.openviking import OpenVikingError
 from app.context_manager.base import ContextQueryResults, QueryResult
 from app.crypto import encrypt_secret
 from app.db.models import BerilUser, OvUserCredential
@@ -241,3 +242,62 @@ async def test_ls_decrypts_stored_key_for_manager(client, credentialed_user):
         client.get("/api/context/ls")
 
     assert cls.call_args.args[1] == "plain-user-key"
+
+
+# ---------------------------------------------------------------------------
+# Credential provisioning
+#
+# ``user`` (not ``credentialed_user``) has no stored credential, so these
+# exercise the first-use path through ``get_user_ov_api_key``.
+# ---------------------------------------------------------------------------
+
+
+async def test_find_provisions_credential_on_first_use(client, user, manager):
+    """A user with no stored key gets one minted transparently — still a 200."""
+    register = AsyncMock(return_value={"user_key": "minted-key"})
+    _login(client)
+    with patch("app.context_manager.openviking.register_ov_user", register):
+        resp = client.post("/api/context/find", json={"query": "alpha"})
+
+    assert resp.status_code == 200
+    register.assert_awaited_once_with(USER_TOKEN["orcid"])
+
+
+async def test_find_uses_freshly_minted_key_for_manager(client, user):
+    register = AsyncMock(return_value={"user_key": "minted-key"})
+    inst = MagicMock()
+    inst.query = AsyncMock(return_value=QUERY_RESULTS)
+    _login(client)
+    with patch("app.context_manager.openviking.register_ov_user", register), patch(
+        "app.routes.context.OpenVikingManager", return_value=inst
+    ) as cls:
+        client.post("/api/context/find", json={"query": "alpha"})
+
+    assert cls.call_args.args[1] == "minted-key"
+
+
+async def test_find_returns_502_when_provisioning_fails(client, user, manager):
+    """Backend failures surface as a generic 502, never as OV specifics."""
+    register = AsyncMock(
+        side_effect=OpenVikingError("boom", status_code=500, code="INTERNAL")
+    )
+    _login(client)
+    with patch("app.context_manager.openviking.register_ov_user", register):
+        resp = client.post("/api/context/find", json={"query": "alpha"})
+
+    assert resp.status_code == 502
+    detail = resp.json()["detail"]
+    assert "openviking" not in detail.lower()
+    manager.query.assert_not_awaited()
+
+
+async def test_ls_returns_502_when_provisioning_fails(client, user, manager):
+    register = AsyncMock(
+        side_effect=OpenVikingError("boom", status_code=500, code="INTERNAL")
+    )
+    _login(client)
+    with patch("app.context_manager.openviking.register_ov_user", register):
+        resp = client.get("/api/context/ls")
+
+    assert resp.status_code == 502
+    manager.list_files.assert_not_awaited()


### PR DESCRIPTION
This one's a little under the hood, but another step toward OpenViking abstraction.

The BERIL webapp now automatically creates OpenViking users and stores / retrieves / updates their credentials as needed to support the /api/context paths. Those credentials don't need to be, and shouldn't be, exposed outside of the webapp. So now they aren't!