### PR TITLE
Route the /submit context mirror through BERIL's ingest API

### DIFF
--- a/.claude/skills/submit/SKILL.md
+++ b/.claude/skills/submit/SKILL.md
@@ -203,7 +203,7 @@ Phase 2c is split into a **pre-write validation pass** (no state mutation) follo
 ##### 2c-pre. Validate inputs and stage memory extractions (no writes yet)
 
 - **Compute notebook hashes (v5)**: invoke `python {repo_root}/tools/notebook_hash.py compute-hashes {project_path}` to get a JSON dict of `{relpath: "sha256:<hex>"}`. Result is sorted by path, ready for stable YAML output. Empty dict for projects without `notebooks/`. Values are already `sha256:`-prefixed and can be written to YAML verbatim. (Read-only; safe to do here.)
-- **Stage memory extractions** from `REPORT.md`. This is how reviewed-and-approved discoveries/performance claims become OV-ingestible memories without contaminating the layer with unvetted synthesizer output. Validate and capture in memory only — no files are written or deleted in this pre-pass.
+- **Stage memory extractions** from `REPORT.md`. This is how reviewed-and-approved discoveries/performance claims become ingestible memories without contaminating the context layer with unvetted synthesizer output. Validate and capture in memory only — no files are written or deleted in this pre-pass.
 
   For each section name in `["Discoveries", "Performance Notes"]` (mapping to `discoveries.md` and `performance.md` respectively):
 
@@ -280,7 +280,18 @@ The script archives all project files to `s3a://cdm-lake/tenant-general-warehous
 mc alias set berdl-minio $MINIO_ENDPOINT_URL $MINIO_ACCESS_KEY $MINIO_SECRET_KEY
 ```
 
-On a successful archive, the upload tool also submits the project files to the BERIL-managed context service so the knowledge layer can see the completed project. That step is handled entirely inside `lakehouse_upload.py` and is **best-effort**: it runs only when BERIL and the context service are available and the user is logged in, and if it is skipped or fails the lakehouse archive still succeeds (the tool reports it in its JSON but does not fail the upload). `/submit` needs no extra handling for it — the exit-code contract below is unchanged.
+On a successful archive, the upload tool also submits the project files to the BERIL-managed context service so the knowledge layer can see the completed project. That step is handled entirely inside `lakehouse_upload.py` and is **best-effort**: it runs only when BERIL is reachable and the user is logged in, and if it is skipped or fails the lakehouse archive still succeeds (the tool reports it in its JSON but does not fail the upload). `/submit` needs no extra handling for it — the exit-code contract below is unchanged.
+
+The mirror goes through BERIL's own HTTP API. `knowledge/scripts/ingest_context.py --project <id> --json` stages the project (curated files, `memories/*.md`, plus the generated `PROJECT_METADATA.md` and `CLAIMS_CONTEXT.md`), zips that tree, and POSTs it with a manifest to `POST /api/context/ingest_files` using the personal access token from `beril login`. The archive is what preserves relative paths — a flat upload would collapse `memories/pitfalls.md` to `pitfalls.md`. Ingest is asynchronous, so the script then polls `GET /api/context/ingest_status/{batch_id}` every few seconds until every file reaches a terminal state (default cap: 10 minutes). A BERIL credential is the only one involved.
+
+Verdict mapping in the tool's `context_submission` JSON:
+
+- all files `completed` → `"ok"`
+- any file `failed` → `"failed"` (the reason names the offending files)
+- poll cap reached with files still queued/processing → `"skipped"` — the files remain queued and may still land, so an unfinished batch is not treated as a failure
+- not logged in, or BERIL unreachable → `"skipped"`
+
+**Scope limitation**: this path uploads files only. Cross-project relations and the `knowledge/state/` change manifest are not updated by it — a mirrored project's manifest entry stays whatever the last interactive ingest run (`--all` / `--changed`) recorded. Run an interactive ingest mode to reconcile either. This does not affect the lakehouse archive or the submission verdict.
 
 **Re-submission overwrite semantics**: the upload script pre-clears the remote prefix (`mc rm --recursive --force`) before `mc cp` whenever the prefix already has contents. This prevents stale files from a previous submission from contaminating the new archive when files are dropped or renamed between submissions. The brief mid-upload window during which the archive is empty is acceptable: a `complete + SUBMISSION_FAILED.md` state already signals "incomplete archive" to anyone consuming it. First-time submissions skip the clear because the remote prefix is empty.
 

--- a/knowledge/scripts/ingest_context.py
+++ b/knowledge/scripts/ingest_context.py
@@ -8,27 +8,38 @@
 #     "rich",
 # ]
 # ///
-"""Ingest BERIL context into OpenViking.
+"""Ingest BERIL context into the knowledge layer.
 
-Two modes, sharing one ingest code path:
+Two modes, reaching the context store by **different routes**:
 
 **Interactive** (default) — Rich progress output, non-zero exit on failure.
 This is the human-facing mode: ``--all``, ``--changed``, ``--project``, ``--docs``.
+It drives the OpenViking SDK directly (``observatory_context.openviking_client``)
+against the credential ``ContextConfig`` resolves, which is why this script's
+PEP-723 header still pins ``openviking``. Only these modes need it.
 
 **Verdict** (``--json``, requires ``--project``) — the *best-effort mirror* used by
 ``tools/lakehouse_upload.py`` after a successful lakehouse archive, so the
-knowledge layer sees the completed project. Three gates must pass first, all
-required:
+knowledge layer sees the completed project.
 
-  1. the BERIL webapp is available,
-  2. the user is logged in with a valid credential, and
-  3. the context service is reachable and accepts that credential.
+The verdict path speaks **only to BERIL**, never to the context backend. It
+uploads the staged project to BERIL's ``/api/context/ingest_files`` route with
+the personal access token from ``beril login`` and polls the batch to
+completion, so a user needs only a BERIL credential — the backend's address,
+key, and task vocabulary stay on the server. Two gates must pass first:
 
-(1)+(2) are proved together by an authenticated health call against BERIL;
-(3) by the context client's own reachability + auth diagnosis (against the
-credential the importer will actually use). If any gate fails we skip — never
-fail — because the lakehouse archive, not the context index, is the source of
-truth for "submitted".
+  1. the user is logged in to BERIL (``~/.beril/auth.json``), and
+  2. the BERIL webapp is reachable and accepts that token.
+
+Both are proved together by an authenticated health call. If either fails we
+skip — never fail — because the lakehouse archive, not the context index, is the
+source of truth for "submitted".
+
+**Scope note**: the mirror uploads files only. ``apply_project_relations`` and
+the ``knowledge/state/`` change manifest are SDK-level operations with no route
+equivalent, so the verdict path skips them; a mirrored project's manifest entry
+stays whatever the last interactive ``--all``/``--changed`` run recorded. Re-run
+an interactive mode to reconcile relations and change tracking.
 
 ``--json`` prints a single line of JSON on stdout (always)::
 
@@ -54,6 +65,10 @@ from rich.panel import Panel
 
 from beril_cli import auth_store
 from beril_cli.ov_client import OvLinkError, ov_health
+from observatory_context.beril_ingest import (
+    BerilIngestError,
+    ingest_project_files,
+)
 from observatory_context.config import ContextConfig
 from observatory_context.ingest import (
     ingest_all,
@@ -62,12 +77,15 @@ from observatory_context.ingest import (
     ingest_project,
     resolve_project_dir,
 )
-from observatory_context.openviking_client import create_client, diagnose
+from observatory_context.openviking_client import create_client
 from observatory_context.progress import RichIngestObserver
+from observatory_context.staging import stage_project
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Ingest BERIL context into OpenViking")
+    parser = argparse.ArgumentParser(
+        description="Ingest BERIL context into the knowledge layer"
+    )
     mode = parser.add_mutually_exclusive_group(required=True)
     mode.add_argument("--all", action="store_true", help="Ingest all selected projects and docs")
     mode.add_argument("--changed", action="store_true", help="Ingest changed selected sources")
@@ -83,9 +101,10 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--json",
         action="store_true",
-        help="Best-effort mirror mode (requires --project): gate on BERIL login + "
-        "context-service health, emit a single-line JSON verdict on stdout, and "
-        "always exit 0. Used by tools/lakehouse_upload.py after a successful archive",
+        help="Best-effort mirror mode (requires --project): upload the staged "
+        "project through BERIL's ingest route and poll it to completion, emit a "
+        "single-line JSON verdict on stdout, and always exit 0. Used by "
+        "tools/lakehouse_upload.py after a successful archive",
     )
     return parser
 
@@ -99,67 +118,77 @@ def _emit(status: str, reason: str) -> int:
     return 0
 
 
-def _preflight() -> tuple[bool, str]:
-    """Check the three gates. Return (ok, reason)."""
-    # Gates 1+2: authenticated health call against BERIL. A 200 proves the
-    # webapp is up and the stored token still authenticates.
+def _preflight() -> tuple[auth_store.AuthRecord | None, str]:
+    """Check the two gates. Return (record, reason); record is None on failure.
+
+    One authenticated health call proves both gates at once: a 200 means the
+    BERIL webapp is up and the stored token still authenticates. No
+    context-backend credential is checked — the route brokers that itself.
+    """
     record = auth_store.load()
     if record is None:
-        return False, (
+        return None, (
             "not logged in to BERIL (no ~/.beril/auth.json); "
             "run `beril login` to enable the context-service submission"
         )
     try:
         ov_health(record.base_url, record.token)
     except OvLinkError as exc:
-        return False, f"BERIL context service health check failed: {exc}"
-
-    # Gate 3: reachability + client-auth against the context service the way the
-    # importer will reach it (ContextConfig resolves the cached credential).
-    diag = diagnose(ContextConfig.from_env())
-    if not diag.ok:
-        return False, f"context service not ready ({diag.verdict}): {diag.detail}"
-    return True, "context service available"
+        return None, f"BERIL context service health check failed: {exc}"
+    return record, "context service available"
 
 
 def run_mirror(project_id: str) -> int:
     """Best-effort single-project mirror. Never raises; always returns 0.
 
-    Shares `ingest_project` with the interactive path — the difference is the
-    gating, the machine-readable verdict, and the promise never to fail the
-    caller. No observer is passed: Rich output would pollute the stdout line
-    the caller parses.
+    Stages the project the same way the interactive path does — so the
+    generated ``PROJECT_METADATA.md`` and ``CLAIMS_CONTEXT.md`` are mirrored
+    alongside the curated files — then uploads that tree to BERIL as a zip plus
+    a manifest and polls the batch to a terminal state.
+
+    A timed-out poll is reported as "skipped", not "failed": the files are
+    queued server-side and may well land, so it is not an outcome worth
+    marking the submission bad over.
     """
     try:
-        ok, reason = _preflight()
+        record, reason = _preflight()
     except Exception as exc:  # unexpected client/transport error
         return _emit("skipped", f"context-service preflight error: {exc}")
-    if not ok:
+    if record is None:
         return _emit("skipped", reason)
 
     config = ContextConfig.from_env()
     try:
-        client = create_client(config)
-    except (SystemExit, Exception) as exc:
-        # create_client raises SystemExit on an unreachable server — that's a
-        # BaseException, so it must be named explicitly; a bare `except
-        # Exception` would let it propagate and kill the caller's upload. The
-        # preflight should have caught this, but guard against the race.
-        return _emit("skipped", f"context service became unreachable: {exc}")
+        project_dir = resolve_project_dir(config, project_id)
+        staged = stage_project(project_dir, config.staging_dir)
+        files = sorted(p for p in staged.rglob("*") if p.is_file())
+    except Exception as exc:
+        return _emit("failed", f"could not stage {project_id} for submission: {exc}")
+
+    # An empty staging tree means nothing was selected for ingest. Report it
+    # rather than posting an empty archive — a silent no-op would look like a
+    # successful mirror.
+    if not files:
+        return _emit("failed", f"{project_id} staged no files to submit")
 
     try:
-        ingest_project(config, client, project_id)
-    except Exception as exc:
+        outcome = ingest_project_files(
+            record.base_url,
+            record.token,
+            project=project_id,
+            root=staged,
+            files=files,
+        )
+    except BerilIngestError as exc:
         return _emit("failed", f"context-service submission failed: {exc}")
-    finally:
-        close = getattr(client, "close", None)
-        if close:
-            try:
-                close()
-            except Exception:
-                pass
+    except Exception as exc:
+        return _emit("failed", f"context-service submission failed unexpectedly: {exc}")
 
-    return _emit("ok", f"submitted {project_id} to context service")
+    if outcome.ok:
+        return _emit("ok", f"submitted {project_id} to context service ({outcome.summary()})")
+    if outcome.timed_out:
+        return _emit("skipped", f"{project_id} ingest still in progress — {outcome.summary()}")
+    return _emit("failed", f"context-service submission failed: {outcome.summary()}")
 
 
 def main() -> None:

--- a/observatory_context/beril_ingest.py
+++ b/observatory_context/beril_ingest.py
@@ -1,0 +1,308 @@
+"""Mirror a project into the context layer through BERIL's HTTP API.
+
+This is the ``/submit`` path. It deliberately does **not** speak OpenViking:
+BERIL brokers the context manager behind ``/api/context/*``, so the CLI holds
+only a BERIL personal access token and never an OV key. OpenViking's address,
+credentials, and task vocabulary stay on the server side.
+
+The wire format is the one ``POST /api/context/ingest_files`` expects:
+
+  * a zip archive carrying the staged project's directory structure, and
+  * a manifest naming which of its members to ingest, one relative path per
+    line.
+
+A plain multipart upload would flatten ``memories/pitfalls.md`` to
+``pitfalls.md``; the archive is what preserves the path. Ingest is asynchronous,
+so submission returns a ``batch_id`` that :func:`poll_batch` follows to a
+terminal state.
+"""
+
+from __future__ import annotations
+
+import io
+import time
+import zipfile
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import httpx
+
+# The context routes are slower than the credential exchange in
+# `beril_cli.ov_client` — an ingest upload carries a whole project archive.
+UPLOAD_TIMEOUT_SECONDS = 120.0
+POLL_TIMEOUT_SECONDS = 30.0
+
+# Poll cadence and ceiling. Ingest is queue-backed, so the wait is dominated by
+# the backend's own indexing, not by us asking too slowly.
+POLL_INTERVAL_SECONDS = 3.0
+POLL_MAX_WAIT_SECONDS = 600.0
+
+INGEST_PATH = "/api/context/ingest_files"
+STATUS_PATH = "/api/context/ingest_status"
+
+# BERIL's ingest vocabulary (see ui/app/context_manager/base.py). Mirrored here
+# rather than imported: the CLI does not depend on the webapp package.
+QUEUED = "queued"
+PROCESSING = "processing"
+COMPLETED = "completed"
+FAILED = "failed"
+UNKNOWN = "unknown"
+
+TERMINAL_STATUSES = frozenset({COMPLETED, FAILED})
+
+
+class BerilIngestError(Exception):
+    """An ingest submission or poll failed. The message is user-facing."""
+
+
+@dataclass
+class IngestOutcome:
+    """The result of one mirror attempt.
+
+    ``ok`` is true only when every manifest file reached ``completed``. A batch
+    that timed out is not a failure of the upload — the files may still land —
+    so it is reported separately via ``timed_out`` and the caller decides how
+    loudly to say so.
+    """
+
+    ok: bool
+    batch_id: str | None
+    status: str
+    counts: dict[str, int] = field(default_factory=dict)
+    failures: list[tuple[str, str | None]] = field(default_factory=list)
+    timed_out: bool = False
+
+    def summary(self) -> str:
+        """One line describing the outcome, suitable for a verdict ``reason``."""
+        if self.ok:
+            n = self.counts.get(COMPLETED, 0)
+            return f"{n} file(s) ingested"
+        if self.timed_out:
+            pending = self.counts.get(QUEUED, 0) + self.counts.get(PROCESSING, 0)
+            return (
+                f"timed out after {POLL_MAX_WAIT_SECONDS:.0f}s with {pending} "
+                f"file(s) still in flight (batch {self.batch_id})"
+            )
+        if self.failures:
+            detail = "; ".join(
+                f"{path}: {reason or 'no reason given'}"
+                for path, reason in self.failures[:5]
+            )
+            more = "" if len(self.failures) <= 5 else f" (+{len(self.failures) - 5} more)"
+            return f"{len(self.failures)} file(s) failed — {detail}{more}"
+        return f"ingest ended in status {self.status!r}"
+
+
+def build_archive(root: Path, files: list[Path]) -> tuple[bytes, list[str]]:
+    """Zip ``files`` relative to ``root``; return ``(archive_bytes, manifest)``.
+
+    The manifest is every archived path, in the order given, so the caller can
+    hand both halves to :func:`submit_ingest` unchanged. Paths are stored
+    POSIX-style because the server splits on ``/``.
+    """
+    root = Path(root).resolve()
+    manifest: list[str] = []
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        for path in files:
+            resolved = Path(path).resolve()
+            if not resolved.is_file():
+                raise BerilIngestError(f"Not a file: {path}")
+            try:
+                relative = resolved.relative_to(root)
+            except ValueError as exc:
+                raise BerilIngestError(
+                    f"{path} is outside the staged project root {root}"
+                ) from exc
+            arcname = relative.as_posix()
+            zf.write(resolved, arcname)
+            manifest.append(arcname)
+
+    if not manifest:
+        raise BerilIngestError(f"No files to ingest under {root}")
+    return buf.getvalue(), manifest
+
+
+def submit_ingest(
+    base_url: str,
+    token: str,
+    *,
+    project: str,
+    archive: bytes,
+    manifest: list[str],
+    client: httpx.Client | None = None,
+) -> dict:
+    """POST one archive + manifest. Returns the decoded ingest response.
+
+    Raises :class:`BerilIngestError` on transport failure or a non-2xx — a
+    rejected upload is a real failure here, unlike the gates in the caller,
+    because the archive was accepted for transmission and then refused.
+    """
+    files = {
+        "archive": (f"{project}.zip", archive, "application/zip"),
+        "manifest": ("manifest.txt", "\n".join(manifest).encode(), "text/plain"),
+    }
+    with _client_ctx(client, UPLOAD_TIMEOUT_SECONDS) as http:
+        try:
+            resp = http.post(
+                _url(base_url, INGEST_PATH),
+                data={"project": project},
+                files=files,
+                headers=_auth(token),
+            )
+        except httpx.HTTPError as exc:
+            raise BerilIngestError(f"could not reach BERIL to ingest: {exc}") from exc
+        _guard(resp, "submit files for ingest")
+        return _json(resp)
+
+
+def poll_batch(
+    base_url: str,
+    token: str,
+    batch_id: str,
+    *,
+    interval: float = POLL_INTERVAL_SECONDS,
+    max_wait: float = POLL_MAX_WAIT_SECONDS,
+    client: httpx.Client | None = None,
+    sleep=time.sleep,
+    monotonic=time.monotonic,
+) -> IngestOutcome:
+    """Poll a batch until every file is terminal, or ``max_wait`` elapses.
+
+    The batch rolls up to ``failed`` as soon as any one file fails, so polling
+    stops there rather than waiting out the rest — the mirror is already not
+    clean. A transport blip mid-poll is retried rather than raised: the files
+    are queued server-side regardless of whether we can currently see them.
+    """
+    deadline = monotonic() + max_wait
+    last: dict = {}
+    with _client_ctx(client, POLL_TIMEOUT_SECONDS) as http:
+        while True:
+            try:
+                resp = http.get(
+                    _url(base_url, f"{STATUS_PATH}/{batch_id}"), headers=_auth(token)
+                )
+                _guard(resp, "check ingest status")
+                last = _json(resp)
+            except BerilIngestError:
+                # Keep the last good reading and try again; only a timeout ends
+                # the loop. A 404 would be permanent, but the batch id came
+                # from a 200 submission, so treating it as transient is safe.
+                last = last or {}
+            else:
+                status = str(last.get("status") or UNKNOWN)
+                if status in TERMINAL_STATUSES:
+                    return _outcome(batch_id, last, timed_out=False)
+
+            if monotonic() >= deadline:
+                return _outcome(batch_id, last, timed_out=True)
+            sleep(min(interval, max(0.0, deadline - monotonic())))
+
+
+def _outcome(batch_id: str, body: dict, *, timed_out: bool) -> IngestOutcome:
+    status = str(body.get("status") or UNKNOWN)
+    counts = body.get("counts") or {}
+    files = body.get("files") or []
+    failures = [
+        (str(f.get("relative_path") or "?"), f.get("error"))
+        for f in files
+        if f.get("status") == FAILED
+    ]
+    return IngestOutcome(
+        ok=(not timed_out and status == COMPLETED and not failures),
+        batch_id=batch_id,
+        status=status,
+        counts={str(k): int(v) for k, v in counts.items()},
+        failures=failures,
+        timed_out=timed_out,
+    )
+
+
+def ingest_project_files(
+    base_url: str,
+    token: str,
+    *,
+    project: str,
+    root: Path,
+    files: list[Path],
+    client: httpx.Client | None = None,
+    **poll_kwargs,
+) -> IngestOutcome:
+    """Archive, submit, and poll to a terminal state. The whole mirror."""
+    archive, manifest = build_archive(root, files)
+    body = submit_ingest(
+        base_url,
+        token,
+        project=project,
+        archive=archive,
+        manifest=manifest,
+        client=client,
+    )
+    batch_id = body.get("batch_id")
+    if not batch_id:
+        # Without a batch id the submission cannot be followed. Report what the
+        # server said about the files it did accept rather than claiming success.
+        raise BerilIngestError(
+            "BERIL accepted the upload but returned no batch_id to poll "
+            f"(queued={body.get('queued')}, failed={body.get('failed')})"
+        )
+    return poll_batch(base_url, token, str(batch_id), client=client, **poll_kwargs)
+
+
+# --- helpers ---------------------------------------------------------------
+
+
+def _url(base_url: str, path: str) -> str:
+    return base_url.rstrip("/") + path
+
+
+class _Borrowed:
+    """Use a caller-supplied client without closing it on exit."""
+
+    def __init__(self, client: httpx.Client) -> None:
+        self._client = client
+
+    def __enter__(self) -> httpx.Client:
+        return self._client
+
+    def __exit__(self, *exc) -> bool:
+        return False
+
+
+def _client_ctx(client: httpx.Client | None, timeout: float):
+    """Borrow the caller's client, or open one for the duration of the call.
+
+    The auth header is attached per-request rather than to the client, so a
+    borrowed client is authenticated the same way an owned one is.
+    """
+    if client is not None:
+        return _Borrowed(client)
+    return httpx.Client(timeout=timeout)
+
+
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _guard(resp: httpx.Response, action: str) -> None:
+    if resp.is_success:
+        return
+    detail = ""
+    try:
+        body = resp.json()
+        if isinstance(body, dict) and body.get("detail"):
+            detail = f": {body['detail']}"
+    except ValueError:
+        text = resp.text.strip()
+        detail = f": {text[:200]}" if text else ""
+    raise BerilIngestError(f"BERIL returned {resp.status_code} on {action}{detail}")
+
+
+def _json(resp: httpx.Response) -> dict:
+    try:
+        body = resp.json()
+    except ValueError as exc:
+        raise BerilIngestError("BERIL returned invalid JSON for the ingest call.") from exc
+    if not isinstance(body, dict):
+        raise BerilIngestError("BERIL returned an unexpected ingest payload.")
+    return body

--- a/tests/knowledge/test_beril_ingest.py
+++ b/tests/knowledge/test_beril_ingest.py
@@ -1,0 +1,291 @@
+"""Tests for the BERIL-route context mirror (`observatory_context.beril_ingest`).
+
+These exercise the archive/manifest wire format and the polling loop against a
+stubbed transport — no BERIL instance and no OpenViking are involved.
+"""
+
+from __future__ import annotations
+
+import io
+import zipfile
+
+import httpx
+import pytest
+
+from observatory_context.beril_ingest import (
+    BerilIngestError,
+    build_archive,
+    ingest_project_files,
+    poll_batch,
+    submit_ingest,
+)
+
+BASE_URL = "https://beril.test"
+TOKEN = "pat-token"
+
+
+def _project(tmp_path, files=None):
+    """Write a small staged project tree; return (root, file list)."""
+    files = files or {"REPORT.md": "report", "memories/pitfalls.md": "pitfall"}
+    root = tmp_path / "staged"
+    for name, content in files.items():
+        path = root / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+    return root, sorted(p for p in root.rglob("*") if p.is_file())
+
+
+def _client(handler):
+    return httpx.Client(transport=httpx.MockTransport(handler), base_url=BASE_URL)
+
+
+def _status_body(status, files, counts=None):
+    return {
+        "batch_id": "batch-1",
+        "project": "proj",
+        "status": status,
+        "counts": counts or {},
+        "files": files,
+    }
+
+
+# --- build_archive ---------------------------------------------------------
+
+
+def test_build_archive_preserves_nested_paths(tmp_path):
+    root, files = _project(tmp_path)
+    archive, manifest = build_archive(root, files)
+
+    with zipfile.ZipFile(io.BytesIO(archive)) as zf:
+        names = sorted(zf.namelist())
+    # The nested path is what a flat multipart upload would have lost.
+    assert names == ["REPORT.md", "memories/pitfalls.md"]
+    assert manifest == names
+
+
+def test_build_archive_manifest_matches_members(tmp_path):
+    root, files = _project(tmp_path, {"a.md": "a", "b/c.md": "c", "b/d/e.md": "e"})
+    archive, manifest = build_archive(root, files)
+
+    with zipfile.ZipFile(io.BytesIO(archive)) as zf:
+        assert sorted(zf.namelist()) == sorted(manifest)
+        assert zf.read("b/d/e.md") == b"e"
+
+
+def test_build_archive_rejects_file_outside_root(tmp_path):
+    root, files = _project(tmp_path)
+    outside = tmp_path / "elsewhere.md"
+    outside.write_text("x", encoding="utf-8")
+
+    with pytest.raises(BerilIngestError, match="outside the staged project root"):
+        build_archive(root, files + [outside])
+
+
+def test_build_archive_rejects_empty_file_list(tmp_path):
+    root, _ = _project(tmp_path)
+    with pytest.raises(BerilIngestError, match="No files to ingest"):
+        build_archive(root, [])
+
+
+# --- submit_ingest ---------------------------------------------------------
+
+
+def test_submit_ingest_posts_archive_manifest_and_project(tmp_path):
+    root, files = _project(tmp_path)
+    archive, manifest = build_archive(root, files)
+    seen = {}
+
+    def handler(request):
+        seen["url"] = str(request.url)
+        seen["auth"] = request.headers.get("Authorization")
+        seen["body"] = request.content
+        return httpx.Response(200, json={"batch_id": "batch-1", "queued": 2, "failed": 0})
+
+    with _client(handler) as http:
+        body = submit_ingest(
+            BASE_URL,
+            TOKEN,
+            project="proj",
+            archive=archive,
+            manifest=manifest,
+            client=http,
+        )
+
+    assert body["batch_id"] == "batch-1"
+    assert seen["url"] == f"{BASE_URL}/api/context/ingest_files"
+    assert seen["auth"] == f"Bearer {TOKEN}"
+    # Multipart carries all three parts the route requires.
+    assert b'name="project"' in seen["body"]
+    assert b'name="archive"' in seen["body"]
+    assert b'name="manifest"' in seen["body"]
+    # The manifest travels as newline-separated relative paths.
+    assert b"memories/pitfalls.md" in seen["body"]
+
+
+def test_submit_ingest_surfaces_server_detail(tmp_path):
+    root, files = _project(tmp_path)
+    archive, manifest = build_archive(root, files)
+
+    def handler(request):
+        return httpx.Response(400, json={"detail": "not a zip file"})
+
+    with _client(handler) as http:
+        with pytest.raises(BerilIngestError, match="400.*not a zip file"):
+            submit_ingest(
+                BASE_URL, TOKEN, project="p", archive=archive, manifest=manifest, client=http
+            )
+
+
+# --- poll_batch ------------------------------------------------------------
+
+
+def test_poll_batch_returns_on_completion():
+    bodies = [
+        _status_body("processing", [{"relative_path": "a.md", "status": "queued"}]),
+        _status_body(
+            "completed",
+            [{"relative_path": "a.md", "status": "completed"}],
+            counts={"completed": 1},
+        ),
+    ]
+    calls = []
+
+    def handler(request):
+        calls.append(str(request.url))
+        return httpx.Response(200, json=bodies[min(len(calls) - 1, len(bodies) - 1)])
+
+    with _client(handler) as http:
+        outcome = poll_batch(
+            BASE_URL, TOKEN, "batch-1", client=http, interval=0, sleep=lambda _: None
+        )
+
+    assert outcome.ok
+    assert outcome.status == "completed"
+    assert len(calls) == 2
+    assert calls[0] == f"{BASE_URL}/api/context/ingest_status/batch-1"
+
+
+def test_poll_batch_stops_on_failure_with_reasons():
+    body = _status_body(
+        "failed",
+        [
+            {"relative_path": "a.md", "status": "completed"},
+            {"relative_path": "b.md", "status": "failed", "error": "rejected"},
+        ],
+        counts={"completed": 1, "failed": 1},
+    )
+
+    with _client(lambda r: httpx.Response(200, json=body)) as http:
+        outcome = poll_batch(
+            BASE_URL, TOKEN, "batch-1", client=http, interval=0, sleep=lambda _: None
+        )
+
+    assert not outcome.ok
+    assert not outcome.timed_out
+    assert outcome.failures == [("b.md", "rejected")]
+    assert "b.md: rejected" in outcome.summary()
+
+
+def test_poll_batch_times_out_without_failing():
+    """An unfinished batch is not a failure — the files may still land."""
+    body = _status_body(
+        "processing",
+        [{"relative_path": "a.md", "status": "queued"}],
+        counts={"queued": 1},
+    )
+    clock = iter([0.0, 0.0, 1.0, 99.0, 99.0, 99.0])
+
+    with _client(lambda r: httpx.Response(200, json=body)) as http:
+        outcome = poll_batch(
+            BASE_URL,
+            TOKEN,
+            "batch-1",
+            client=http,
+            interval=0,
+            max_wait=10,
+            sleep=lambda _: None,
+            monotonic=lambda: next(clock),
+        )
+
+    assert not outcome.ok
+    assert outcome.timed_out
+    assert "still in flight" in outcome.summary()
+
+
+def test_poll_batch_retries_through_a_transport_blip():
+    """A blip mid-poll keeps polling — the batch is queued server-side."""
+    responses = [
+        httpx.Response(503, text="upstream down"),
+        httpx.Response(
+            200,
+            json=_status_body(
+                "completed",
+                [{"relative_path": "a.md", "status": "completed"}],
+                counts={"completed": 1},
+            ),
+        ),
+    ]
+    calls = []
+
+    def handler(request):
+        calls.append(1)
+        return responses[min(len(calls) - 1, len(responses) - 1)]
+
+    with _client(handler) as http:
+        outcome = poll_batch(
+            BASE_URL, TOKEN, "batch-1", client=http, interval=0, sleep=lambda _: None
+        )
+
+    assert outcome.ok
+    assert len(calls) == 2
+
+
+# --- ingest_project_files --------------------------------------------------
+
+
+def test_ingest_project_files_submits_then_polls(tmp_path):
+    root, files = _project(tmp_path)
+    seen = []
+
+    def handler(request):
+        seen.append(request.url.path)
+        if request.url.path.endswith("/ingest_files"):
+            return httpx.Response(200, json={"batch_id": "b7", "queued": 2, "failed": 0})
+        return httpx.Response(
+            200,
+            json=_status_body(
+                "completed",
+                [{"relative_path": "REPORT.md", "status": "completed"}],
+                counts={"completed": 2},
+            ),
+        )
+
+    with _client(handler) as http:
+        outcome = ingest_project_files(
+            BASE_URL,
+            TOKEN,
+            project="proj",
+            root=root,
+            files=files,
+            client=http,
+            interval=0,
+            sleep=lambda _: None,
+        )
+
+    assert outcome.ok
+    assert outcome.batch_id == "b7"
+    assert seen == ["/api/context/ingest_files", "/api/context/ingest_status/b7"]
+
+
+def test_ingest_project_files_errors_without_a_batch_id(tmp_path):
+    """No batch id means the submission cannot be followed — never call it ok."""
+    root, files = _project(tmp_path)
+
+    def handler(request):
+        return httpx.Response(200, json={"queued": 0, "failed": 2})
+
+    with _client(handler) as http:
+        with pytest.raises(BerilIngestError, match="no batch_id"):
+            ingest_project_files(
+                BASE_URL, TOKEN, project="proj", root=root, files=files, client=http
+            )


### PR DESCRIPTION
## Summary

The best-effort context mirror that runs after a successful lakehouse archive talked to OpenViking directly, so a user needed an OV key on their machine to submit a project. This routes it through BERIL's `/api/context/ingest_files` endpoint instead — the CLI now holds only a BERIL personal access token, and the backend's address, credential, and task vocabulary stay server-side.

Builds on the archive+manifest endpoint in 5cb50df2. A multipart upload loses relative paths (`memories/pitfalls.md` collapses to `pitfalls.md`), so the mirror zips the staged tree and sends a manifest naming which members to ingest.

## Changes

**New — `observatory_context/beril_ingest.py`**
- `build_archive()` — zips the staged tree, POSIX-relative paths preserved
- `submit_ingest()` — POSTs archive + manifest + project with the `beril login` PAT
- `poll_batch()` — polls `/api/context/ingest_status/{batch_id}` every 3s until terminal (10 min cap), retrying through transport blips since the batch is queued server-side regardless
- `ingest_project_files()` — the whole flow; returns an `IngestOutcome` separating success / per-file failures / timeout

**`knowledge/scripts/ingest_context.py`** — `--json` verdict mode only. Preflight drops from three gates to two (logged in, BERIL reachable); the backend-credential diagnosis is gone. Still calls `stage_project()`, so the generated `PROJECT_METADATA.md` and `CLAIMS_CONTEXT.md` ship as before.

**`.claude/skills/submit/SKILL.md`** — Phase 3b describes the archive-and-poll flow and its verdict mapping. No backend named anywhere in the skill.

## Scope and consequences

- **Interactive modes are unconverted.** `--all`/`--changed`/`--project`/`--docs` still drive the SDK directly, which is why the PEP-723 header keeps its `openviking` pin. The module docstring now says so instead of claiming the whole script targets OpenViking. Note this means `/submit` still installs an SDK it no longer uses — splitting the verdict mode into its own httpx-only script would fix that, deferred for now.
- **A timed-out poll reports `skipped`, not `failed`.** The files are queued server-side and may still land; the lakehouse archive remains the source of truth for "submitted".
- **Relations and the `knowledge/state/` manifest are skipped** — SDK-level operations with no route equivalent. A mirrored project's manifest entry stays whatever the last interactive run recorded, so a later `--changed` will re-ingest it. Re-run an interactive mode to reconcile.

## Testing

`tests/knowledge/test_beril_ingest.py` — 12 cases over `httpx.MockTransport`: nested-path preservation, manifest/member agreement, files outside the staged root, multipart shape, completion, failure-with-reasons, timeout, blip retry, and the missing-`batch_id` case. No BERIL instance or backend needed.

Full suite: 766 passed.

Writing these caught two bugs in the first draft — a caller-supplied client bypassed the auth header, and `ingest_project_files` swallowed `client` into `**poll_kwargs` so the submit call never received it. Auth is now attached per-request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
