### PR TITLE
Context Manager ingest should skip unchanged files

### DIFF
--- a/.claude/skills/submit/SKILL.md
+++ b/.claude/skills/submit/SKILL.md
@@ -284,9 +284,12 @@ On a successful archive, the upload tool also submits the project files to the B
 
 The mirror goes through BERIL's own HTTP API. `knowledge/scripts/ingest_context.py --project <id> --json` stages the project (curated files, `memories/*.md`, plus the generated `PROJECT_METADATA.md` and `CLAIMS_CONTEXT.md`), zips that tree, and POSTs it with a manifest to `POST /api/context/ingest_files` using the personal access token from `beril login`. The archive is what preserves relative paths — a flat upload would collapse `memories/pitfalls.md` to `pitfalls.md`. Ingest is asynchronous, so the script then polls `GET /api/context/ingest_status/{batch_id}` every few seconds until every file reaches a terminal state (default cap: 10 minutes). A BERIL credential is the only one involved.
 
+The context service skips any file whose exact content it already holds, so re-running `/submit` on an unchanged project sends nothing and completes immediately. Only a file that actually *landed* counts as current — one that failed or is still indexing is sent again, so a retry after a failure always does real work.
+
 Verdict mapping in the tool's `context_submission` JSON:
 
 - all files `completed` → `"ok"`
+- every file already current, nothing sent → `"ok"` (reported as "already current")
 - any file `failed` → `"failed"` (the reason names the offending files)
 - poll cap reached with files still queued/processing → `"skipped"` — the files remain queued and may still land, so an unfinished batch is not treated as a failure
 - not logged in, or BERIL unreachable → `"skipped"`

--- a/knowledge/scripts/ingest_context.py
+++ b/knowledge/scripts/ingest_context.py
@@ -149,6 +149,10 @@ def run_mirror(project_id: str) -> int:
     A timed-out poll is reported as "skipped", not "failed": the files are
     queued server-side and may well land, so it is not an outcome worth
     marking the submission bad over.
+
+    The server skips files whose content it already holds, so a re-submission
+    of unchanged work sends nothing and reports "ok" — there is no batch to
+    poll in that case.
     """
     try:
         record, reason = _preflight()
@@ -185,6 +189,10 @@ def run_mirror(project_id: str) -> int:
         return _emit("failed", f"context-service submission failed unexpectedly: {exc}")
 
     if outcome.ok:
+        # "submitted" would be a lie when the server already had every file, so
+        # a no-op mirror says so plainly. Both are "ok": the content is there.
+        if outcome.batch_id is None:
+            return _emit("ok", f"{project_id} already current — {outcome.summary()}")
         return _emit("ok", f"submitted {project_id} to context service ({outcome.summary()})")
     if outcome.timed_out:
         return _emit("skipped", f"{project_id} ingest still in progress — {outcome.summary()}")

--- a/observatory_context/beril_ingest.py
+++ b/observatory_context/beril_ingest.py
@@ -47,6 +47,9 @@ PROCESSING = "processing"
 COMPLETED = "completed"
 FAILED = "failed"
 UNKNOWN = "unknown"
+# The server already had this exact content, so it was never submitted. Only
+# ever seen in the ingest response — a skipped file joins no batch.
+SKIPPED = "skipped"
 
 TERMINAL_STATUSES = frozenset({COMPLETED, FAILED})
 
@@ -59,10 +62,14 @@ class BerilIngestError(Exception):
 class IngestOutcome:
     """The result of one mirror attempt.
 
-    ``ok`` is true only when every manifest file reached ``completed``. A batch
-    that timed out is not a failure of the upload — the files may still land —
-    so it is reported separately via ``timed_out`` and the caller decides how
-    loudly to say so.
+    ``ok`` is true only when every manifest file reached ``completed`` — or was
+    skipped as already-current, which is equally a success: the content is in
+    the store either way. A batch that timed out is not a failure of the upload
+    (the files may still land), so it is reported separately via ``timed_out``
+    and the caller decides how loudly to say so.
+
+    ``batch_id`` is ``None`` when the server skipped every file. Nothing was
+    submitted, so there is no batch and nothing was polled.
     """
 
     ok: bool
@@ -71,11 +78,16 @@ class IngestOutcome:
     counts: dict[str, int] = field(default_factory=dict)
     failures: list[tuple[str, str | None]] = field(default_factory=list)
     timed_out: bool = False
+    skipped: int = 0
 
     def summary(self) -> str:
         """One line describing the outcome, suitable for a verdict ``reason``."""
         if self.ok:
             n = self.counts.get(COMPLETED, 0)
+            if self.skipped and not n:
+                return f"{self.skipped} file(s) already current; nothing to send"
+            if self.skipped:
+                return f"{n} file(s) ingested, {self.skipped} already current"
             return f"{n} file(s) ingested"
         if self.timed_out:
             pending = self.counts.get(QUEUED, 0) + self.counts.get(PROCESSING, 0)
@@ -239,14 +251,32 @@ def ingest_project_files(
         client=client,
     )
     batch_id = body.get("batch_id")
+    queued = int(body.get("queued") or 0)
+    failed = int(body.get("failed") or 0)
+    skipped = int(body.get("skipped") or 0)
+
     if not batch_id:
-        # Without a batch id the submission cannot be followed. Report what the
-        # server said about the files it did accept rather than claiming success.
+        # No batch means nothing was submitted. That is success when every file
+        # was skipped as already-current — the content is in the store, so there
+        # is nothing to poll. Any other shape is a submission we cannot follow.
+        if not queued and not failed:
+            return IngestOutcome(
+                ok=True,
+                batch_id=None,
+                status=COMPLETED,
+                counts={SKIPPED: skipped},
+                skipped=skipped,
+            )
         raise BerilIngestError(
             "BERIL accepted the upload but returned no batch_id to poll "
-            f"(queued={body.get('queued')}, failed={body.get('failed')})"
+            f"(queued={queued}, failed={failed})"
         )
-    return poll_batch(base_url, token, str(batch_id), client=client, **poll_kwargs)
+
+    outcome = poll_batch(base_url, token, str(batch_id), client=client, **poll_kwargs)
+    # The batch only tracks what was submitted, so skips are known from the
+    # submission response alone and have to be carried across.
+    outcome.skipped = skipped
+    return outcome
 
 
 # --- helpers ---------------------------------------------------------------

--- a/tests/knowledge/test_beril_ingest.py
+++ b/tests/knowledge/test_beril_ingest.py
@@ -278,14 +278,85 @@ def test_ingest_project_files_submits_then_polls(tmp_path):
 
 
 def test_ingest_project_files_errors_without_a_batch_id(tmp_path):
-    """No batch id means the submission cannot be followed — never call it ok."""
+    """A submission we cannot follow is an error — files were accepted but
+    no handle came back to poll them with."""
     root, files = _project(tmp_path)
 
     def handler(request):
-        return httpx.Response(200, json={"queued": 0, "failed": 2})
+        return httpx.Response(200, json={"queued": 2, "failed": 0})
 
     with _client(handler) as http:
         with pytest.raises(BerilIngestError, match="no batch_id"):
             ingest_project_files(
                 BASE_URL, TOKEN, project="proj", root=root, files=files, client=http
             )
+
+
+def test_ingest_project_files_treats_all_skipped_as_success(tmp_path):
+    """Every file already current: no batch, nothing polled, still ok.
+
+    The server sends no batch_id when it submitted nothing, so this must not be
+    mistaken for a submission that lost its handle.
+    """
+    root, files = _project(tmp_path)
+    calls = []
+
+    def handler(request):
+        calls.append(request.url.path)
+        return httpx.Response(
+            200, json={"batch_id": None, "queued": 0, "failed": 0, "skipped": 2}
+        )
+
+    with _client(handler) as http:
+        outcome = ingest_project_files(
+            BASE_URL, TOKEN, project="proj", root=root, files=files, client=http
+        )
+
+    assert outcome.ok
+    assert outcome.batch_id is None
+    assert outcome.skipped == 2
+    # Nothing to poll, so the status endpoint is never touched.
+    assert calls == ["/api/context/ingest_files"]
+    assert "already current" in outcome.summary()
+
+
+def test_ingest_project_files_carries_skips_across_a_poll(tmp_path):
+    """A mixed batch: skips come from the submission, not the batch status."""
+    root, files = _project(tmp_path)
+
+    def handler(request):
+        if request.url.path.endswith("/ingest_files"):
+            return httpx.Response(
+                200, json={"batch_id": "b1", "queued": 1, "failed": 0, "skipped": 3}
+            )
+        return httpx.Response(
+            200,
+            json=_status_body(
+                "completed",
+                [{"relative_path": "REPORT.md", "status": "completed"}],
+                counts={"completed": 1},
+            ),
+        )
+
+    with _client(handler) as http:
+        outcome = ingest_project_files(
+            BASE_URL, TOKEN, project="proj", root=root, files=files, client=http,
+            interval=0, sleep=lambda _: None,
+        )
+
+    assert outcome.ok
+    assert outcome.skipped == 3
+    assert outcome.summary() == "1 file(s) ingested, 3 already current"
+
+
+def test_all_skipped_response_missing_the_field_is_still_success(tmp_path):
+    """A server that omits `skipped` entirely still reads as a clean no-op."""
+    root, files = _project(tmp_path)
+
+    with _client(lambda r: httpx.Response(200, json={"queued": 0, "failed": 0})) as http:
+        outcome = ingest_project_files(
+            BASE_URL, TOKEN, project="proj", root=root, files=files, client=http
+        )
+
+    assert outcome.ok
+    assert outcome.skipped == 0

--- a/ui/alembic/versions/20260909_a7b8c9d0e1f2_add_context_ingest_content_hash.py
+++ b/ui/alembic/versions/20260909_a7b8c9d0e1f2_add_context_ingest_content_hash.py
@@ -1,0 +1,71 @@
+"""Add content_sha256 to context_ingest_file.
+
+Records the hash of the bytes submitted for each ingested file, so a later
+ingest can skip a file whose content already landed. Nullable by design: rows
+written before this column existed carry no hash, and a null must never compare
+equal to an incoming file — those always re-ingest.
+
+The composite index supports the skip lookup, which filters on relative_path
+and status together.
+
+Revision ID: a7b8c9d0e1f2
+Revises: f6a1b2c3d4e5
+Create Date: 2026-09-09
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "a7b8c9d0e1f2"
+down_revision = "f6a1b2c3d4e5"
+branch_labels = None
+depends_on = None
+
+_TABLE = "context_ingest_file"
+_COLUMN = "content_sha256"
+_INDEX = "ix_context_ingest_file_path_status"
+
+
+def _column_exists(table: str, column: str) -> bool:
+    conn = op.get_bind()
+    return bool(
+        conn.execute(
+            sa.text(
+                "SELECT EXISTS ("
+                "  SELECT 1 FROM information_schema.columns"
+                "  WHERE table_name = :table AND column_name = :column"
+                ")"
+            ),
+            {"table": table, "column": column},
+        ).scalar()
+    )
+
+
+def _index_exists(name: str) -> bool:
+    conn = op.get_bind()
+    return bool(
+        conn.execute(
+            sa.text(
+                "SELECT EXISTS ("
+                "  SELECT 1 FROM pg_indexes WHERE indexname = :name"
+                ")"
+            ),
+            {"name": name},
+        ).scalar()
+    )
+
+
+def upgrade() -> None:
+    # Guarded the same way the table-creating revision is, so a re-run against a
+    # partially migrated database is safe.
+    if not _column_exists(_TABLE, _COLUMN):
+        op.add_column(_TABLE, sa.Column(_COLUMN, sa.String(64), nullable=True))
+    if not _index_exists(_INDEX):
+        op.create_index(_INDEX, _TABLE, ["relative_path", "status"])
+
+
+def downgrade() -> None:
+    if _index_exists(_INDEX):
+        op.drop_index(_INDEX, table_name=_TABLE)
+    if _column_exists(_TABLE, _COLUMN):
+        op.drop_column(_TABLE, _COLUMN)

--- a/ui/app/context_manager/base.py
+++ b/ui/app/context_manager/base.py
@@ -38,8 +38,14 @@ INGEST_COMPLETED = "completed"
 INGEST_FAILED = "failed"
 # The backend forgot the task before we saw it finish — we genuinely don't know.
 INGEST_UNKNOWN = "unknown"
+# Identical content already completed for this project, so nothing was sent.
+# Reported per-file rather than silently omitted: a missing file in the response
+# is indistinguishable from a bug when the user's file doesn't turn up.
+INGEST_SKIPPED = "skipped"
 
-TERMINAL_INGEST_STATUSES = frozenset({INGEST_COMPLETED, INGEST_FAILED})
+TERMINAL_INGEST_STATUSES = frozenset(
+    {INGEST_COMPLETED, INGEST_FAILED, INGEST_SKIPPED}
+)
 
 # Every status, in lifecycle order — used to render a stable counts mapping.
 INGEST_STATUSES = (
@@ -48,6 +54,7 @@ INGEST_STATUSES = (
     INGEST_COMPLETED,
     INGEST_FAILED,
     INGEST_UNKNOWN,
+    INGEST_SKIPPED,
 )
 
 
@@ -67,10 +74,16 @@ class IngestResult(BaseModel):
 
 
 class ContextIngestResults(BaseModel):
-    """Outcome of one submission. ``batch_id`` is the handle for polling it."""
+    """Outcome of one submission. ``batch_id`` is the handle for polling it.
+
+    ``batch_id`` is ``None`` when nothing was submitted — every file was
+    skipped as unchanged, so no batch exists and there is nothing to poll.
+    Callers must treat that as success, not as a missing handle.
+    """
     results: list[IngestResult]
     queued: int
     failed: int
+    skipped: int = 0
     batch_id: str | None = None
 
 

--- a/ui/app/db/crud.py
+++ b/ui/app/db/crud.py
@@ -4,11 +4,12 @@ import hashlib
 import secrets
 from datetime import datetime, timedelta, timezone
 
-from sqlalchemy import delete, select
+from sqlalchemy import delete, func, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
+from app.context_manager.base import INGEST_COMPLETED
 from app.db.models import (
     BerilUser,
     ContextIngestBatch,
@@ -467,7 +468,7 @@ async def create_ingest_batch(
     """Record one ingest submission and its per-file outcomes.
 
     ``files`` entries carry ``relative_path``, ``status``, and optionally
-    ``uri``, ``ov_task_id``, and ``error``.
+    ``uri``, ``ov_task_id``, ``error``, and ``content_sha256``.
     """
     batch = ContextIngestBatch(
         user_id=user_id, project_id=project_id, target_root=target_root
@@ -483,11 +484,59 @@ async def create_ingest_batch(
                 ov_task_id=f.get("ov_task_id"),
                 status=f["status"],
                 error=f.get("error"),
+                content_sha256=f.get("content_sha256"),
             )
         )
     await db.commit()
     await db.refresh(batch)
     return batch
+
+
+async def completed_file_hashes(
+    db: AsyncSession, project_id: str
+) -> dict[str, str]:
+    """Return ``{relative_path: content_sha256}`` for this project's landed files.
+
+    Only rows whose *latest* record is ``completed`` are returned, so a file
+    that later failed or was re-queued is absent and will re-ingest. Rows with a
+    null hash (written before the column existed) are excluded — there is no
+    basis for comparison, so those must re-ingest too.
+
+    Deliberately avoids ``DISTINCT ON``: production runs Postgres but the tests
+    run SQLite, and a Postgres-only construct here would pass review and fail in
+    CI. The row-number window function works on both.
+    """
+    latest = (
+        select(
+            ContextIngestFileRecord.relative_path,
+            ContextIngestFileRecord.status,
+            ContextIngestFileRecord.content_sha256,
+            func.row_number()
+            .over(
+                partition_by=ContextIngestFileRecord.relative_path,
+                order_by=(
+                    ContextIngestFileRecord.created_at.desc(),
+                    ContextIngestFileRecord.id.desc(),
+                ),
+            )
+            .label("rn"),
+        )
+        .join(
+            ContextIngestBatch,
+            ContextIngestFileRecord.batch_id == ContextIngestBatch.id,
+        )
+        .where(ContextIngestBatch.project_id == project_id)
+        .subquery()
+    )
+
+    result = await db.execute(
+        select(latest.c.relative_path, latest.c.content_sha256).where(
+            latest.c.rn == 1,
+            latest.c.status == INGEST_COMPLETED,
+            latest.c.content_sha256.is_not(None),
+        )
+    )
+    return {row.relative_path: row.content_sha256 for row in result}
 
 
 async def get_ingest_batch(

--- a/ui/app/db/models.py
+++ b/ui/app/db/models.py
@@ -324,9 +324,19 @@ class ContextIngestFileRecord(Base):
     is BERIL's own vocabulary (``queued``/``processing``/``completed``/
     ``failed``/``unknown``), not the backend's — see ``INGEST_STATUS`` in the
     context_manager package.
+
+    ``content_sha256`` is the hash of the bytes submitted, letting a later
+    ingest skip a file whose content already landed. It is nullable because
+    rows written before the column existed have no hash: a null must never
+    compare equal to anything, so those files always re-ingest.
     """
 
     __tablename__ = "context_ingest_file"
+    __table_args__ = (
+        # Supports the "has this path already completed?" lookup that drives
+        # skip-on-unchanged, which filters on both columns.
+        Index("ix_context_ingest_file_path_status", "relative_path", "status"),
+    )
 
     id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_new_uuid)
     batch_id: Mapped[str] = mapped_column(
@@ -340,6 +350,7 @@ class ContextIngestFileRecord(Base):
     ov_task_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
     status: Mapped[str] = mapped_column(String(32), nullable=False)
     error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    content_sha256: Mapped[str | None] = mapped_column(String(64), nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_now)
     updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_now, onupdate=_now)
 

--- a/ui/app/routes/context.py
+++ b/ui/app/routes/context.py
@@ -9,6 +9,7 @@ within BERIL's context manager implementation.
 """
 
 import asyncio
+import hashlib
 import io
 import logging
 import mimetypes
@@ -37,11 +38,14 @@ from app.context_manager.base import (
     INGEST_FAILED,
     INGEST_PROCESSING,
     INGEST_QUEUED,
+    INGEST_SKIPPED,
     INGEST_STATUSES,
     INGEST_UNKNOWN,
     TERMINAL_INGEST_STATUSES,
+    ContextIngestResults,
     IngestBatchStatus,
     IngestFileStatus,
+    IngestResult,
 )
 from app.context_manager.openviking import (
     ContextIngestFile,
@@ -51,9 +55,11 @@ from app.context_manager.openviking import (
     UnauthenticatedError,
     context_slugify,
     get_user_ov_api_key,
+    target_uri,
     user_target_root,
 )
 from app.db.crud import (
+    completed_file_hashes,
     create_ingest_batch,
     create_user_project,
     get_ingest_batch,
@@ -224,6 +230,7 @@ async def post_context_ingest_files(
     project: str = Form(...),
     archive: UploadFile = File(...),
     manifest: UploadFile = File(...),
+    force: bool = Form(False),
     user: BerilUser = Depends(require_user_api),
     db: AsyncSession = Depends(get_db)
 ):
@@ -238,10 +245,21 @@ async def post_context_ingest_files(
     status means the context manager accepted the file, and it becomes
     searchable some time later. Each file reports its own status, so a partial
     batch still returns 200 with the failures named.
+
+    A file whose content already *completed* an ingest for this project is
+    skipped rather than re-sent, making a re-submission of unchanged work a
+    no-op. Only ``completed`` counts: a file that failed, is still in flight, or
+    predates content hashing re-ingests, so a user's retry after a failure
+    always does something. ``force=true`` bypasses the check entirely — the
+    repair path for content the backend lost or must re-index.
+
+    When every file is skipped nothing is submitted, so no batch exists and
+    ``batch_id`` is ``None``. That is success, not a missing handle.
     """
     settings = get_settings()
     manager = await resolve_context_manager(db, user)
     db_project = await _resolve_project(db, user, project)
+    target_root = user_target_root(user.orcid_id, db_project.slug)
 
     archive_bytes = await archive.read()
 
@@ -271,7 +289,14 @@ async def post_context_ingest_files(
 
         logger.info(f"ingesting files: {relative_paths}")
 
+        # What this project already has, so identical content is not re-sent.
+        # Skipped entirely under force: the point of the flag is to re-ingest
+        # regardless of what we believe already landed.
+        landed = {} if force else await completed_file_hashes(db, db_project.id)
+
         ingest_files = []
+        content_hashes: dict[str, str] = {}
+        skipped: list[IngestResult] = []
         for relative_path in relative_paths:
             source = root / relative_path
             size = source.stat().st_size
@@ -283,25 +308,54 @@ async def post_context_ingest_files(
                         f"(limit {settings.context_max_file_bytes})."
                     ),
                 )
+            content = await asyncio.to_thread(source.read_bytes)
+            # Recorded against the batch row so a later ingest can tell whether
+            # this exact content already landed.
+            digest = hashlib.sha256(content).hexdigest()
+            if landed.get(relative_path) == digest:
+                # Reported, not omitted: the response accounts for every
+                # manifest entry so a skip can't be mistaken for a lost file.
+                # No batch row is written — a skip is not an ingest attempt, and
+                # recording one would let it satisfy a later skip check without
+                # anything ever having been indexed.
+                skipped.append(
+                    IngestResult(
+                        relative_path=relative_path,
+                        status=INGEST_SKIPPED,
+                        uri=target_uri(target_root, relative_path),
+                        reason="Identical content already ingested.",
+                    )
+                )
+                continue
+            content_hashes[relative_path] = digest
             ingest_files.append(
                 ContextIngestFile(
                     relative_path=relative_path,
-                    content=await asyncio.to_thread(source.read_bytes),
+                    content=content,
                     content_type=mimetypes.guess_type(relative_path)[0],
                 )
             )
 
-    target_root = user_target_root(user.orcid_id, db_project.slug)
     logger.info(
-        "Ingesting %d file(s) to %s for user %s",
+        "Ingesting %d file(s) to %s for user %s (%d unchanged)",
         len(ingest_files),
         target_root,
         user.orcid_id,
+        len(skipped),
     )
+
+    # Everything was unchanged: nothing to submit, so no batch and nothing to
+    # poll. Answered as a success with the skips enumerated.
+    if not ingest_files:
+        return ContextIngestResults(
+            results=skipped, queued=0, failed=0, skipped=len(skipped)
+        )
+
     results = await manager.insert_files(ingest_files, target_root=target_root)
 
     # Record the submission so its progress stays pollable: the context
     # manager expires its own task records and does not track who owns them.
+    # Only submitted files get rows — see the skip branch above.
     batch = await create_ingest_batch(
         db,
         user_id=user.id,
@@ -314,11 +368,14 @@ async def post_context_ingest_files(
                 "ov_task_id": r.task_id,
                 "status": r.status,
                 "error": r.reason,
+                "content_sha256": content_hashes.get(r.relative_path),
             }
             for r in results.results
         ],
     )
     results.batch_id = batch.id
+    results.results = results.results + skipped
+    results.skipped = len(skipped)
     return results
 
 
@@ -385,6 +442,9 @@ def _rollup_status(files: list[IngestFileStatus]) -> str:
     Failure wins over everything — a batch with a failed file is not a success,
     however many others landed. Unfinished work outranks a clean sweep, and
     ``unknown`` only surfaces once nothing is still in flight.
+
+    ``skipped`` never appears here: a skipped file is not submitted and so
+    writes no batch row. It is reported only in the ingest response.
     """
     statuses = {f.status for f in files}
     if INGEST_FAILED in statuses:

--- a/ui/tests/test_routes_context.py
+++ b/ui/tests/test_routes_context.py
@@ -8,6 +8,7 @@ OV payload to ``ContextQueryResults`` is covered in ``test_context_manager.py``.
 
 from __future__ import annotations
 
+import hashlib
 import io
 import os
 import zipfile
@@ -338,12 +339,15 @@ def _ingest(
     members=None,
     manifest=None,
     archive=None,
+    force=None,
 ):
     """Post an ingest request.
 
     Defaults to a one-file archive whose manifest lists exactly that file.
     ``manifest`` defaults to every member of the archive, so a test that only
-    cares about the archive contents does not have to restate them.
+    cares about the archive contents does not have to restate them. ``force``
+    is omitted from the form unless set, so the default path exercises the
+    route's own default.
     """
     members = {"notes.md": b"hi"} if members is None else members
     manifest = list(members) if manifest is None else manifest
@@ -351,9 +355,12 @@ def _ingest(
     manifest_bytes = (
         manifest if isinstance(manifest, bytes) else "\n".join(manifest).encode()
     )
+    data = {"project": project}
+    if force is not None:
+        data["force"] = str(force).lower()
     return client.post(
         "/api/context/ingest_files",
-        data={"project": project},
+        data=data,
         files={
             "archive": ("upload.zip", archive, "application/zip"),
             "manifest": ("manifest.txt", manifest_bytes, "text/plain"),
@@ -700,6 +707,70 @@ async def test_ingest_returns_a_batch_id(client, credentialed_user, ingest_manag
     assert batch_id
 
 
+async def test_ingest_records_content_hash(
+    client, credentialed_user, ingest_manager, db_session
+):
+    """The submitted bytes are hashed onto the batch row.
+
+    This is what lets a later ingest tell whether identical content already
+    landed, so the recorded value must be the hash of what was actually sent.
+    """
+    ingest_manager.insert_files.return_value = _queued_with_tasks([("a.md", "t1")])
+    _login(client)
+    resp = _ingest(client, members={"a.md": b"contents"})
+    assert resp.status_code == 200
+
+    batch = await get_ingest_batch(db_session, resp.json()["batch_id"])
+    assert [f.content_sha256 for f in batch.files] == [
+        hashlib.sha256(b"contents").hexdigest()
+    ]
+
+
+async def test_ingest_records_distinct_hashes_per_file(
+    client, credentialed_user, ingest_manager, db_session
+):
+    """Each file is hashed independently, matched to it by relative path."""
+    ingest_manager.insert_files.return_value = _queued_with_tasks(
+        [("a.md", "t1"), ("sub/b.md", "t2")]
+    )
+    _login(client)
+    resp = _ingest(client, members={"a.md": b"aaa", "sub/b.md": b"bbb"})
+    assert resp.status_code == 200
+
+    batch = await get_ingest_batch(db_session, resp.json()["batch_id"])
+    recorded = {f.relative_path: f.content_sha256 for f in batch.files}
+    assert recorded == {
+        "a.md": hashlib.sha256(b"aaa").hexdigest(),
+        "sub/b.md": hashlib.sha256(b"bbb").hexdigest(),
+    }
+
+
+async def test_ingest_records_no_hash_for_a_file_never_read(
+    client, credentialed_user, ingest_manager, db_session
+):
+    """A result the manager reports for a path we never read carries no hash.
+
+    Defensive: the hash must come from bytes this request actually handled, so
+    an unmatched path records null rather than borrowing another file's hash.
+    """
+    ingest_manager.insert_files.return_value = ContextIngestResults(
+        results=[
+            IngestResult(relative_path="a.md", status="queued", uri="viking://a"),
+            IngestResult(relative_path="ghost.md", status="failed", reason="nope"),
+        ],
+        queued=1,
+        failed=1,
+    )
+    _login(client)
+    resp = _ingest(client, members={"a.md": b"aaa"})
+    assert resp.status_code == 200
+
+    batch = await get_ingest_batch(db_session, resp.json()["batch_id"])
+    recorded = {f.relative_path: f.content_sha256 for f in batch.files}
+    assert recorded["a.md"] == hashlib.sha256(b"aaa").hexdigest()
+    assert recorded["ghost.md"] is None
+
+
 def test_ingest_status_unauthenticated_returns_401(client):
     assert client.get("/api/context/ingest_status/anything").status_code == 401
 
@@ -864,7 +935,7 @@ async def test_ingest_status_includes_project_slug(
 async def test_ingest_status_counts_cover_every_status(
     client, credentialed_user, ingest_manager
 ):
-    """counts always carries all five keys, so clients can index it blindly."""
+    """counts always carries every status key, so clients can index it blindly."""
     _login(client)
     batch_id = await _start_batch(client, ingest_manager, [("a.md", "t1")])
 
@@ -879,4 +950,242 @@ async def test_ingest_status_counts_cover_every_status(
         "completed",
         "failed",
         "unknown",
+        # Present for a stable mapping, though a skipped file never reaches a
+        # batch: it is not submitted, so it writes no row.
+        "skipped",
     }
+    assert counts["skipped"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Skip-on-unchanged (content hash)
+# ---------------------------------------------------------------------------
+
+
+async def _land(client, ingest_manager, db_session, members):
+    """Ingest ``members`` and mark every resulting file completed.
+
+    Leaves the project in the state the skip check reads: content whose latest
+    record is ``completed`` with a hash.
+    """
+    ingest_manager.insert_files.return_value = _queued_with_tasks(
+        [(p, f"task-{i}") for i, p in enumerate(sorted(members))]
+    )
+    resp = _ingest(client, members=members)
+    assert resp.status_code == 200
+    batch = await get_ingest_batch(db_session, resp.json()["batch_id"])
+    for f in batch.files:
+        f.status = "completed"
+    await db_session.commit()
+    return batch.id
+
+
+async def test_ingest_skips_unchanged_file(
+    client, credentialed_user, ingest_manager, db_session
+):
+    """Identical content that already completed is not re-sent."""
+    _login(client)
+    await _land(client, ingest_manager, db_session, {"a.md": b"same"})
+
+    ingest_manager.insert_files.reset_mock()
+    resp = _ingest(client, members={"a.md": b"same"})
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert (body["queued"], body["skipped"]) == (0, 1)
+    assert body["results"][0]["status"] == "skipped"
+    ingest_manager.insert_files.assert_not_awaited()
+
+
+async def test_ingest_resends_changed_content(
+    client, credentialed_user, ingest_manager, db_session
+):
+    _login(client)
+    await _land(client, ingest_manager, db_session, {"a.md": b"before"})
+
+    ingest_manager.insert_files.return_value = _queued_with_tasks([("a.md", "t2")])
+    resp = _ingest(client, members={"a.md": b"after"})
+
+    assert resp.status_code == 200
+    assert resp.json()["skipped"] == 0
+    sent = ingest_manager.insert_files.await_args.args[0]
+    assert [f.relative_path for f in sent] == ["a.md"]
+
+
+async def test_ingest_sends_a_new_path(
+    client, credentialed_user, ingest_manager, db_session
+):
+    _login(client)
+    await _land(client, ingest_manager, db_session, {"a.md": b"same"})
+
+    ingest_manager.insert_files.return_value = _queued_with_tasks([("b.md", "t2")])
+    resp = _ingest(client, members={"b.md": b"new"})
+
+    assert resp.status_code == 200
+    sent = ingest_manager.insert_files.await_args.args[0]
+    assert [f.relative_path for f in sent] == ["b.md"]
+
+
+async def test_ingest_resends_after_a_failure(
+    client, credentialed_user, ingest_manager, db_session
+):
+    """The critical case: a failed file must re-ingest despite matching bytes.
+
+    Otherwise a transient failure becomes permanent and the user's retry
+    silently does nothing.
+    """
+    _login(client)
+    ingest_manager.insert_files.return_value = _queued_with_tasks([("a.md", "t1")])
+    resp = _ingest(client, members={"a.md": b"same"})
+    batch = await get_ingest_batch(db_session, resp.json()["batch_id"])
+    for f in batch.files:
+        f.status = "failed"
+    await db_session.commit()
+
+    ingest_manager.insert_files.return_value = _queued_with_tasks([("a.md", "t2")])
+    resp = _ingest(client, members={"a.md": b"same"})
+
+    assert resp.status_code == 200
+    assert resp.json()["skipped"] == 0
+    sent = ingest_manager.insert_files.await_args.args[0]
+    assert [f.relative_path for f in sent] == ["a.md"]
+
+
+async def test_ingest_resends_while_still_queued(
+    client, credentialed_user, ingest_manager, db_session
+):
+    """An in-flight file has not landed; its outcome is unknown."""
+    _login(client)
+    ingest_manager.insert_files.return_value = _queued_with_tasks([("a.md", "t1")])
+    _ingest(client, members={"a.md": b"same"})
+
+    ingest_manager.insert_files.return_value = _queued_with_tasks([("a.md", "t2")])
+    resp = _ingest(client, members={"a.md": b"same"})
+
+    assert resp.json()["skipped"] == 0
+    sent = ingest_manager.insert_files.await_args.args[0]
+    assert [f.relative_path for f in sent] == ["a.md"]
+
+
+async def test_ingest_resends_when_prior_hash_is_null(
+    client, credentialed_user, ingest_manager, db_session
+):
+    """A pre-hash row gives no basis for comparison, so it re-ingests."""
+    _login(client)
+    batch_id = await _land(client, ingest_manager, db_session, {"a.md": b"same"})
+    batch = await get_ingest_batch(db_session, batch_id)
+    for f in batch.files:
+        f.content_sha256 = None
+    await db_session.commit()
+
+    ingest_manager.insert_files.return_value = _queued_with_tasks([("a.md", "t2")])
+    resp = _ingest(client, members={"a.md": b"same"})
+
+    assert resp.json()["skipped"] == 0
+    ingest_manager.insert_files.assert_awaited()
+
+
+async def test_ingest_uses_the_latest_record_for_a_path(
+    client, credentialed_user, ingest_manager, db_session
+):
+    """Two batches for one path: the most recent hash decides."""
+    _login(client)
+    await _land(client, ingest_manager, db_session, {"a.md": b"v1"})
+    await _land(client, ingest_manager, db_session, {"a.md": b"v2"})
+
+    ingest_manager.insert_files.reset_mock()
+    # v2 is current, so it skips.
+    assert _ingest(client, members={"a.md": b"v2"}).json()["skipped"] == 1
+    ingest_manager.insert_files.assert_not_awaited()
+
+    # v1 is stale, so it re-ingests.
+    ingest_manager.insert_files.return_value = _queued_with_tasks([("a.md", "t9")])
+    assert _ingest(client, members={"a.md": b"v1"}).json()["skipped"] == 0
+    ingest_manager.insert_files.assert_awaited()
+
+
+async def test_ingest_does_not_skip_across_projects(
+    client, credentialed_user, ingest_manager, db_session
+):
+    """Identical content in another project is not this project's content."""
+    _login(client)
+    await _land(client, ingest_manager, db_session, {"a.md": b"same"})
+
+    ingest_manager.insert_files.return_value = _queued_with_tasks([("a.md", "t2")])
+    resp = _ingest(client, project="Other Project", members={"a.md": b"same"})
+
+    assert resp.json()["skipped"] == 0
+    ingest_manager.insert_files.assert_awaited()
+
+
+async def test_force_reingests_unchanged_files(
+    client, credentialed_user, ingest_manager, db_session
+):
+    _login(client)
+    await _land(client, ingest_manager, db_session, {"a.md": b"same"})
+
+    ingest_manager.insert_files.return_value = _queued_with_tasks([("a.md", "t2")])
+    resp = _ingest(client, members={"a.md": b"same"}, force=True)
+
+    assert resp.status_code == 200
+    assert resp.json()["skipped"] == 0
+    sent = ingest_manager.insert_files.await_args.args[0]
+    assert [f.relative_path for f in sent] == ["a.md"]
+
+
+async def test_ingest_all_skipped_returns_no_batch_id(
+    client, credentialed_user, ingest_manager, db_session
+):
+    """Nothing submitted means no batch — that is success, not a lost handle."""
+    _login(client)
+    await _land(client, ingest_manager, db_session, {"a.md": b"same"})
+
+    ingest_manager.insert_files.reset_mock()
+    resp = _ingest(client, members={"a.md": b"same"})
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["batch_id"] is None
+    assert (body["queued"], body["failed"], body["skipped"]) == (0, 0, 1)
+    ingest_manager.insert_files.assert_not_awaited()
+
+
+async def test_ingest_mixed_batch_accounts_for_every_file(
+    client, credentialed_user, ingest_manager, db_session
+):
+    """A partial skip still reports one result per manifest entry."""
+    _login(client)
+    await _land(client, ingest_manager, db_session, {"a.md": b"same"})
+
+    ingest_manager.insert_files.return_value = _queued_with_tasks([("b.md", "t2")])
+    resp = _ingest(client, members={"a.md": b"same", "b.md": b"new"})
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert (body["queued"], body["skipped"]) == (1, 1)
+    by_path = {r["relative_path"]: r["status"] for r in body["results"]}
+    assert by_path == {"a.md": "queued", "b.md": "skipped"} or by_path == {
+        "b.md": "queued",
+        "a.md": "skipped",
+    }
+    # Only the submitted file was sent to the manager.
+    sent = ingest_manager.insert_files.await_args.args[0]
+    assert [f.relative_path for f in sent] == ["b.md"]
+
+
+async def test_skipped_files_write_no_batch_rows(
+    client, credentialed_user, ingest_manager, db_session
+):
+    """A skip is not an ingest attempt.
+
+    Recording one would let it satisfy a later skip check even though nothing
+    was ever indexed.
+    """
+    _login(client)
+    await _land(client, ingest_manager, db_session, {"a.md": b"same"})
+
+    ingest_manager.insert_files.return_value = _queued_with_tasks([("b.md", "t2")])
+    resp = _ingest(client, members={"a.md": b"same", "b.md": b"new"})
+
+    batch = await get_ingest_batch(db_session, resp.json()["batch_id"])
+    assert [f.relative_path for f in batch.files] == ["b.md"]


### PR DESCRIPTION
When submitting a project, the context manager route scans all files to see if anything is unchanged, and only resubmits files to the context manager (OpenViking) if those files are changed.

This also involves tracking SHA-256 hashes for each ingested file, which is on the path to keeping local files stored for retrieval later.