### PR TITLE
Extend /api/context/find toward query parity

### DIFF
--- a/ui/app/clients/openviking.py
+++ b/ui/app/clients/openviking.py
@@ -88,12 +88,49 @@ class OpenVikingClient:
     async def close(self):
         await self._client.close()
 
-    async def find(self, query: str, target_uri: str|None = None, limit: int = 10, score_threshold: float|None=None) -> dict:
-        options = None
-        if score_threshold is not None:
-            options = {"score_threshold": score_threshold}
-        result = await self._client.find(query, limit=limit, target_uri=target_uri, options=options)
-        return result
+    async def find(
+        self,
+        query: str,
+        target_uri: str | None = None,
+        limit: int = 10,
+        score_threshold: float | None = None,
+        *,
+        filter: dict | None = None,
+        since: str | None = None,
+        until: str | None = None,
+        time_field: str | None = None,
+        node_limit: int | None = None,
+        read_content: bool = False,
+    ) -> dict:
+        """Semantic search.
+
+        Options are built by omission: a key absent from the dict lets the
+        backend apply its own default, which is not the same as passing None.
+        The time bounds are handed over as given — the backend owns that
+        grammar, so translating it here would only add a second thing to keep
+        in sync.
+        """
+        options = {
+            key: value
+            for key, value in (
+                ("score_threshold", score_threshold),
+                ("filter", filter),
+                ("since", since),
+                ("until", until),
+                ("time_field", time_field),
+                ("node_limit", node_limit),
+                # Sent only when asked: the default is the backend's, and
+                # False is a meaningful value we must not imply.
+                ("read_content", read_content or None),
+            )
+            if value is not None
+        }
+        return await self._client.find(
+            query,
+            limit=limit,
+            target_uri=target_uri,
+            options=options or None,
+        )
 
     async def list_files(self, root_path: str) -> dict:
         result = await self._client.ls(f"viking://{root_path}")

--- a/ui/app/context_manager/base.py
+++ b/ui/app/context_manager/base.py
@@ -1,7 +1,14 @@
 from datetime import datetime
 from pathlib import Path
+from typing import Any, Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
+
+# Upper bounds on what a caller may ask the backend for. Not tuning knobs — a
+# query is rejected rather than forwarded when it exceeds these, so one request
+# cannot ask the backend to walk its whole graph.
+MAX_FIND_LIMIT = 200
+MAX_FIND_NODE_LIMIT = 10_000
 
 
 class FileMetadata(BaseModel):
@@ -104,20 +111,54 @@ class IngestBatchStatus(BaseModel):
 
 
 class ContextQuery(BaseModel):
+    """One semantic search against the context layer.
+
+    ``filter`` is a backend metadata filter tree, passed through as given —
+    callers that need one are already reaching past the simple case. The time
+    bounds accept whatever the backend accepts (an ISO date, or a relative form
+    like ``7d``); they are validated as non-empty strings here and interpreted
+    downstream, so a malformed bound is the backend's to reject.
+
+    ``read_content`` asks for each hit's full text, not just its abstract. It
+    is off by default because a broad query would otherwise return every
+    matching document in full.
+    """
+
     query: str
     root_path: str | None = None
-    limit: int = 10
+    limit: int = Field(default=10, ge=1, le=MAX_FIND_LIMIT)
     score_threshold: float | None = None
+    filter: dict[str, Any] | None = None
+    since: str | None = None
+    until: str | None = None
+    time_field: Literal["updated_at", "created_at"] | None = None
+    node_limit: int | None = Field(default=None, ge=1, le=MAX_FIND_NODE_LIMIT)
+    read_content: bool = False
+
 
 class QueryResult(BaseModel):
+    """One hit.
+
+    ``text`` is the abstract — a summary, not the document. ``content`` carries
+    the full text and is present only when the query asked for it, so an absent
+    ``content`` means "not requested", never "empty document".
+    """
+
     uri: str
     context_type: str
     score: float
     text: str
+    match_reason: str | None = None
+    content: str | None = None
+
 
 class ContextQueryResults(BaseModel):
+    """``total`` is the backend's own count, which may exceed ``len(results)``
+    when the query was limited."""
+
     query: str
     results: list[QueryResult]
+    total: int = 0
 
 class ContextManager:
     url: str

--- a/ui/app/context_manager/openviking.py
+++ b/ui/app/context_manager/openviking.py
@@ -49,6 +49,17 @@ INGEST_FAILURES: tuple[type[Exception], ...] = (
     ValueError,
 )
 
+# Expected read-path failures: the backend rejecting a query, or the transport
+# dropping. Named here rather than in the routes so the backend's exception
+# types stay inside this module — a route catching SdkOpenVikingError would put
+# the store's name back in the layer that exists to hide it. Deliberately not
+# bare Exception: a bug in our own mapping code should surface as a 500.
+QUERY_FAILURES: tuple[type[Exception], ...] = (
+    SdkOpenVikingError,
+    OpenVikingError,
+    httpx.HTTPError,
+)
+
 # OpenViking's six task states collapsed onto BERIL's four. "cancelling" is
 # reported as processing because BERIL exposes no cancel, and "cancelled" as
 # failed because the file did not land either way.
@@ -246,25 +257,45 @@ class OpenVikingManager(ContextManager):
 
     async def query(self, query: ContextQuery) -> ContextQueryResults:
         ov_client = await OpenVikingClient.create(self.api_key, base_url=self.url)
-        results = await ov_client.find(
-            query.query,
-            target_uri=query.root_path,
-            limit=query.limit,
-            score_threshold=query.score_threshold
-        )
-        processed = ContextQueryResults(
+        try:
+            results = await ov_client.find(
+                query.query,
+                target_uri=query.root_path,
+                limit=query.limit,
+                score_threshold=query.score_threshold,
+                filter=query.filter,
+                since=query.since,
+                until=query.until,
+                time_field=query.time_field,
+                node_limit=query.node_limit,
+                read_content=query.read_content,
+            )
+        finally:
+            # Closed even when the search raises, so a failed query does not
+            # leak the connection.
+            await ov_client.close()
+
+        resources = results.get("resources") or []
+        return ContextQueryResults(
             query=query.query,
-            results = [
+            results=[
                 QueryResult(
-                    uri=r.get("uri"),
-                    context_type=r.get("context_type"),
-                    score=r.get("score"),
-                    text=r.get("abstract")
-                ) for r in results.get("resources", [])
-            ]
+                    uri=r.get("uri") or "",
+                    context_type=r.get("context_type") or "",
+                    score=r.get("score") or 0.0,
+                    # The abstract is a summary; `content` is the document, and
+                    # only present when the caller asked to read it.
+                    text=r.get("abstract") or "",
+                    match_reason=r.get("match_reason"),
+                    content=r.get("content"),
+                )
+                for r in resources
+            ],
+            # The backend's own count when it reports one — it can exceed the
+            # number of rows returned under a limit.
+            total=results.get("total") if results.get("total") is not None
+            else len(resources),
         )
-        await ov_client.close()
-        return processed
 
 async def get_user_ov_api_key(db: AsyncSession, user: BerilUser) -> str:
     """

--- a/ui/app/routes/context.py
+++ b/ui/app/routes/context.py
@@ -43,11 +43,13 @@ from app.context_manager.base import (
     INGEST_UNKNOWN,
     TERMINAL_INGEST_STATUSES,
     ContextIngestResults,
+    ContextQueryResults,
     IngestBatchStatus,
     IngestFileStatus,
     IngestResult,
 )
 from app.context_manager.openviking import (
+    QUERY_FAILURES,
     ContextIngestFile,
     ContextQuery,
     OpenVikingManager,
@@ -106,10 +108,29 @@ async def post_context_find(
     request: Request,
     user: BerilUser = Depends(require_user_api),
     db: AsyncSession = Depends(get_db)
-):
-    logger.info(f"Running context query: {query} for user {user.orcid_id}")
+) -> ContextQueryResults:
+    """Semantic search over the caller's context layer.
+
+    Bounds and types are enforced by ``ContextQuery``, so a malformed request
+    is a 422 before the backend is touched. A backend that rejects or cannot
+    answer the query surfaces as 502 — the store is an implementation detail,
+    so its error text is logged rather than returned.
+    """
+    logger.info(
+        "Context query %r (limit=%d) for user %s",
+        query.query,
+        query.limit,
+        user.orcid_id,
+    )
     manager = await resolve_context_manager(db, user)
-    return await manager.query(query)
+    try:
+        return await manager.query(query)
+    except QUERY_FAILURES as exc:
+        logger.warning("Context query failed for user %s: %s", user.id, exc)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="The context manager could not answer that query.",
+        ) from exc
 
 @ROUTER_CONTEXT.get("/api/context/ls")
 async def get_context_files(

--- a/ui/tests/test_context_manager.py
+++ b/ui/tests/test_context_manager.py
@@ -205,6 +205,130 @@ async def test_query_forwards_all_query_fields(settings, patched_sdk):
     )
 
 
+async def test_query_forwards_the_extended_options(settings, patched_sdk):
+    """Filter, time bounds, node limit and read_content all reach the backend."""
+    manager = OpenVikingManager(settings, "user-key")
+    await manager.query(
+        ContextQuery(
+            query="alpha",
+            root_path="viking://resources/projects",
+            limit=5,
+            score_threshold=0.5,
+            filter={"op": "must", "field": "uri", "conds": ["viking://x/"]},
+            since="7d",
+            until="2026-01-01",
+            time_field="created_at",
+            node_limit=50,
+            read_content=True,
+        )
+    )
+
+    assert patched_sdk.find.await_args.kwargs["options"] == {
+        "score_threshold": 0.5,
+        "filter": {"op": "must", "field": "uri", "conds": ["viking://x/"]},
+        "since": "7d",
+        "until": "2026-01-01",
+        "time_field": "created_at",
+        "node_limit": 50,
+        "read_content": True,
+    }
+
+
+async def test_query_omits_unset_options(settings, patched_sdk):
+    """An unset option is absent, not None.
+
+    Sending ``None`` would override the backend's own default with a value the
+    caller never chose.
+    """
+    manager = OpenVikingManager(settings, "user-key")
+    await manager.query(ContextQuery(query="alpha"))
+
+    assert patched_sdk.find.await_args.kwargs["options"] is None
+
+
+async def test_query_omits_read_content_when_false(settings, patched_sdk):
+    """``read_content=False`` is the default, so it is not sent at all."""
+    manager = OpenVikingManager(settings, "user-key")
+    await manager.query(ContextQuery(query="alpha", read_content=False))
+
+    assert patched_sdk.find.await_args.kwargs["options"] is None
+
+
+async def test_query_maps_match_reason_and_content(settings, patched_sdk):
+    patched_sdk.find.return_value = {
+        "resources": [
+            {
+                "uri": "viking://x/a.md",
+                "context_type": "document",
+                "score": 0.8,
+                "abstract": "a summary",
+                "match_reason": "matched on title",
+                "content": "the whole document",
+            }
+        ],
+        "total": 1,
+    }
+    manager = OpenVikingManager(settings, "user-key")
+    out = await manager.query(ContextQuery(query="alpha", read_content=True))
+
+    assert out.results[0].match_reason == "matched on title"
+    assert out.results[0].content == "the whole document"
+    # The abstract stays in ``text`` — content is the document, not a summary.
+    assert out.results[0].text == "a summary"
+
+
+async def test_query_reports_backend_total_over_row_count(settings, patched_sdk):
+    """A limited query still reports how many the backend found."""
+    patched_sdk.find.return_value = {
+        "resources": [
+            {"uri": "viking://x/a.md", "context_type": "d", "score": 1.0,
+             "abstract": "a"}
+        ],
+        "total": 97,
+    }
+    manager = OpenVikingManager(settings, "user-key")
+    out = await manager.query(ContextQuery(query="alpha", limit=1))
+
+    assert out.total == 97
+    assert len(out.results) == 1
+
+
+async def test_query_falls_back_to_row_count_without_a_total(settings, patched_sdk):
+    patched_sdk.find.return_value = {
+        "resources": [
+            {"uri": "viking://x/a.md", "context_type": "d", "score": 1.0,
+             "abstract": "a"},
+            {"uri": "viking://x/b.md", "context_type": "d", "score": 0.9,
+             "abstract": "b"},
+        ]
+    }
+    manager = OpenVikingManager(settings, "user-key")
+    out = await manager.query(ContextQuery(query="alpha"))
+
+    assert out.total == 2
+
+
+async def test_query_tolerates_missing_fields_in_a_hit(settings, patched_sdk):
+    """A hit missing uri/score/abstract maps to empty values, not a 500."""
+    patched_sdk.find.return_value = {"resources": [{}]}
+    manager = OpenVikingManager(settings, "user-key")
+    out = await manager.query(ContextQuery(query="alpha"))
+
+    r = out.results[0]
+    assert (r.uri, r.context_type, r.score, r.text) == ("", "", 0.0, "")
+
+
+async def test_query_closes_the_client_when_find_raises(settings, patched_sdk):
+    """A failed query must not leak the connection."""
+    patched_sdk.find.side_effect = UnavailableError("backend down")
+    manager = OpenVikingManager(settings, "user-key")
+
+    with pytest.raises(UnavailableError):
+        await manager.query(ContextQuery(query="alpha"))
+
+    patched_sdk.close.assert_awaited_once()
+
+
 async def test_query_handles_empty_resources(settings, patched_sdk):
     patched_sdk.find.return_value = {"resources": []}
     manager = OpenVikingManager(settings, "user-key")

--- a/ui/tests/test_routes_context.py
+++ b/ui/tests/test_routes_context.py
@@ -18,6 +18,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from cryptography.fernet import Fernet
 from fastapi.testclient import TestClient
+from openviking_sdk.errors import UnavailableError
 
 from app.clients.openviking import OpenVikingError
 from app.config import get_settings
@@ -173,6 +174,10 @@ async def test_find_returns_mapped_results(client, credentialed_user, manager):
             "context_type": "document",
             "score": 0.93,
             "text": "Alpha project overview.",
+            # Absent from this fixture's hit, so they serialize as null rather
+            # than being omitted — clients can index them unconditionally.
+            "match_reason": None,
+            "content": None,
         }
     ]
 
@@ -233,6 +238,105 @@ async def test_find_rejects_malformed_limit(client, credentialed_user, manager):
 
     assert resp.status_code == 422
     manager.query.assert_not_awaited()
+
+
+async def test_find_forwards_the_extended_options(client, credentialed_user, manager):
+    _login(client)
+    resp = client.post(
+        "/api/context/find",
+        json={
+            "query": "alpha",
+            "filter": {"op": "must", "field": "uri", "conds": ["viking://x/"]},
+            "since": "7d",
+            "until": "2026-01-01",
+            "time_field": "created_at",
+            "node_limit": 50,
+            "read_content": True,
+        },
+    )
+
+    assert resp.status_code == 200
+    sent = manager.query.await_args.args[0]
+    assert sent.filter == {"op": "must", "field": "uri", "conds": ["viking://x/"]}
+    assert (sent.since, sent.until, sent.time_field) == ("7d", "2026-01-01", "created_at")
+    assert sent.node_limit == 50
+    assert sent.read_content is True
+
+
+async def test_find_applies_extended_defaults(client, credentialed_user, manager):
+    """The new options are all opt-in; none changes behavior when omitted."""
+    _login(client)
+    client.post("/api/context/find", json={"query": "alpha"})
+
+    sent = manager.query.await_args.args[0]
+    assert sent.filter is None
+    assert (sent.since, sent.until, sent.time_field) == (None, None, None)
+    assert sent.node_limit is None
+    assert sent.read_content is False
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"query": "a", "limit": 0},
+        {"query": "a", "limit": 100000},
+        {"query": "a", "node_limit": 0},
+        {"query": "a", "node_limit": 10_000_000},
+    ],
+)
+async def test_find_rejects_out_of_range_limits(
+    client, credentialed_user, manager, payload
+):
+    """An absurd limit is refused rather than forwarded to the backend."""
+    _login(client)
+    resp = client.post("/api/context/find", json=payload)
+
+    assert resp.status_code == 422
+    manager.query.assert_not_awaited()
+
+
+async def test_find_rejects_a_non_object_filter(client, credentialed_user, manager):
+    _login(client)
+    resp = client.post(
+        "/api/context/find", json={"query": "a", "filter": ["not", "an", "object"]}
+    )
+
+    assert resp.status_code == 422
+    manager.query.assert_not_awaited()
+
+
+async def test_find_rejects_an_unknown_time_field(client, credentialed_user, manager):
+    _login(client)
+    resp = client.post(
+        "/api/context/find", json={"query": "a", "time_field": "whenever"}
+    )
+
+    assert resp.status_code == 422
+    manager.query.assert_not_awaited()
+
+
+async def test_find_surfaces_backend_failure_as_502(client, credentialed_user):
+    """The store is an implementation detail; its errors are not the user's."""
+    inst = MagicMock()
+    inst.query = AsyncMock(side_effect=UnavailableError("backend down"))
+    _login(client)
+    with patch("app.routes.context.OpenVikingManager", return_value=inst):
+        resp = client.post("/api/context/find", json={"query": "alpha"})
+
+    assert resp.status_code == 502
+    # The backend's own message must not leak into the response.
+    assert "backend down" not in resp.text
+
+
+async def test_find_reports_total(client, credentialed_user, manager):
+    manager.query = AsyncMock(
+        return_value=ContextQueryResults(query="alpha", results=[], total=42)
+    )
+    _login(client)
+    resp = client.post("/api/context/find", json={"query": "alpha"})
+
+    assert resp.status_code == 200
+    assert resp.json()["total"] == 42
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The route dropped most of what `knowledge_query.py find` can express: metadata filters, time bounds, a node limit, and full-document reads. Any skill needing those had to reach past BERIL to the backend directly, which is what keeps the backend's name in `.claude`.

ContextQuery gains filter, since/until, time_field, node_limit and read_content. QueryResult gains match_reason and content; results gain the backend's own total, which can exceed the rows returned under a limit. `text` still carries the abstract — content is the document, not a summary, so they are separate fields.

Limits are bounded rather than forwarded: a query asking the backend to walk its whole graph is a 422 before the backend is touched. Options are built by omission, since sending None would override a backend default the caller never chose — notably read_content=False, which is meaningful.

Query failures now surface as 502 instead of 500, via a QUERY_FAILURES tuple defined alongside the existing INGEST_FAILURES. It lives in the context_manager module deliberately: a route catching the SDK's own exception types would put the store's name back in the layer that exists to hide it. The client is also closed when find raises, which it was not before.

First of several route extensions; the CLI and skill rewrites depend on this surface existing.